### PR TITLE
Remove unnecessary @Inject

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/kubernetes/discovery/KubernetesDiscoveryClient.java
+++ b/discovery-client/src/main/java/io/micronaut/kubernetes/discovery/KubernetesDiscoveryClient.java
@@ -53,7 +53,6 @@ public class KubernetesDiscoveryClient implements DiscoveryClient {
 
     private final KubernetesClient client;
 
-    @Inject
     public KubernetesDiscoveryClient(KubernetesClient client) {
         this.client = client;
     }


### PR DESCRIPTION
@Inject in the constructor will only be necessary if we had several constructos. E.g. a deprecated constructor and a new one. 