### PR TITLE
Group should be io.micronaut.configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ ext {
 subprojects { Project subproject ->
 
     version project.projectVersion
-    group "io.micronaut.kubernetes"
+    group "io.micronaut.configuration"
     ext {
         isConfiguration = subproject.projectDir.parentFile.name == 'configurations'
         isBuildSnapshot = version.toString().endsWith("-SNAPSHOT")


### PR DESCRIPTION
I would suggest renaming core to `kubernetes-core` and `service-discovery` to `kubernetes-service-discovery`. `micronaut` prefix is added automatically to the modules upon publication.