### PR TITLE
Replace int->long to make possible use configmap watcher in openshift 1.5.1

### DIFF
--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesOperations.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesOperations.java
@@ -109,7 +109,7 @@ public interface KubernetesOperations {
      */
     @Get("/watch/namespaces/{namespace}/configmaps?resourceVersion={resourceVersion}&labelSelector={labelSelector}")
     @Consumes(value = {MediaType.APPLICATION_JSON_STREAM, MediaType.APPLICATION_JSON})
-    Publisher<ConfigMapWatchEvent> watchConfigMaps(String namespace, Integer resourceVersion, @Nullable String labelSelector);
+    Publisher<ConfigMapWatchEvent> watchConfigMaps(String namespace, Long resourceVersion, @Nullable String labelSelector);
 
     /**
      * Read the specified ConfigMap.

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
@@ -80,7 +80,7 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public void onApplicationEvent(ServiceStartedEvent event) {
-        int lastResourceVersion = computeLastResourceVersion();
+        long lastResourceVersion = computeLastResourceVersion();
         String labelSelector = computeLabelSelector(configuration.getConfigMaps().getLabels());
 
         if (LOG.isDebugEnabled()) {
@@ -98,15 +98,15 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
                 .subscribe(this::processEvent);
     }
 
-    private int computeLastResourceVersion() {
-        int lastResourceVersion = this.environment
+    private long computeLastResourceVersion() {
+        long lastResourceVersion = this.environment
                 .getPropertySources()
                 .stream()
                 .filter(propertySource -> propertySource.getName().endsWith(KUBERNETES_CONFIG_MAP_NAME_SUFFIX))
                 .map(propertySource -> propertySource.get(KubernetesConfigurationClient.CONFIG_MAP_RESOURCE_VERSION))
-                .map(o -> Integer.parseInt(o.toString()))
-                .max(Integer::compareTo)
-                .orElse(0);
+                .map(o -> Long.parseLong(o.toString()))
+                .max(Long::compareTo)
+                .orElse(0L);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Latest resourceVersion is: {}", lastResourceVersion);


### PR DESCRIPTION
Hello.

I've found that micronaut-kubernetes module isn't compatible with some old versions of Openshift (I've checked 1.5.1).

Test case:

Deploy some micronaut application with micronaut-kubernetes to openshift 1.5.1 with configMap which needs to be discovered;

ER: application starts, configMap is discovered;

AR: application throws error:

```
07:32:13.717 [main] ERROR io.micronaut.runtime.Micronaut - Error starting Micronaut server: Unable to start Micronaut server on port: 8080
--
  | io.micronaut.http.server.exceptions.ServerStartupException: Unable to start Micronaut server on port: 8080
  | at io.micronaut.http.server.netty.NettyHttpServer.bindServerToHost(NettyHttpServer.java:446)
  | at io.micronaut.http.server.netty.NettyHttpServer.start(NettyHttpServer.java:318)
  | at io.micronaut.http.server.netty.NettyHttpServer.start(NettyHttpServer.java:96)
  | at io.micronaut.runtime.Micronaut.lambda$start$2(Micronaut.java:75)
  | at java.util.Optional.ifPresent(Optional.java:159)
  | at io.micronaut.runtime.Micronaut.start(Micronaut.java:73)
  | at io.micronaut.runtime.Micronaut.run(Micronaut.java:303)
  | at io.micronaut.runtime.Micronaut.run(Micronaut.java:289)
  | at Application.main(Application.java:18)
  | Caused by: java.lang.NumberFormatException: For input string: "3090130101"
  | at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
  | at java.lang.Integer.parseInt(Integer.java:583)
  | at java.lang.Integer.parseInt(Integer.java:615)
  | at io.micronaut.kubernetes.configuration.KubernetesConfigMapWatcher.lambda$computeLastResourceVersion$4(KubernetesConfigMapWatcher.java:107)
  | at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
  | at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
  | at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
  | at java.util.concurrent.ConcurrentHashMap$ValueSpliterator.forEachRemaining(ConcurrentHashMap.java:3566)
  | at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
  | at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
  | at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
  | at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
  | at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:479)
  | at java.util.stream.ReferencePipeline.max(ReferencePipeline.java:515)
  | at io.micronaut.kubernetes.configuration.KubernetesConfigMapWatcher.computeLastResourceVersion(KubernetesConfigMapWatcher.java:108)
  | at io.micronaut.kubernetes.configuration.KubernetesConfigMapWatcher.onApplicationEvent(KubernetesConfigMapWatcher.java:83)
  | at io.micronaut.kubernetes.configuration.KubernetesConfigMapWatcher.onApplicationEvent(KubernetesConfigMapWatcher.java:50)
```

According to comparison of configMap's content from two openshift instances: 3.11 vs 1.5.1 they have different length of resourceVersion field:

`resourceVersion: '3090130101' ` at 1.5.1 oc version;

`resourceVersion: '362415695'` at 3.11 oc version;

Current pull request replaces "int" variable by "long" one to resolve above issue.
Fix was checked via deployment application to the target oc envrionments (1.5.1 and 3.11) and it works well for both versions.

Could you check the fix and include it to the next releases, if it's possible?