### PR TITLE
Remove assumption on cluster domain name

### DIFF
--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesConfiguration.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesConfiguration.java
@@ -57,7 +57,7 @@ public class KubernetesConfiguration extends HttpClientConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesConfiguration.class);
 
-    private static final String KUBERNETES_DEFAULT_HOST = "kubernetes.default.svc.cluster.local";
+    private static final String KUBERNETES_DEFAULT_HOST = "kubernetes.default.svc";
     private static final int KUBERNETES_DEFAULT_PORT = 443;
     private static final boolean KUBERNETES_DEFAULT_SECURE = true;
 


### PR DESCRIPTION
Not all Kubernetes clusters use `cluster.local` as their domain.

At least in my cluster `kubernetes.default.svc` is one of the Subject Alternate Names in the TLS certificate.

For safety, you can check by executing the following from a container inside the cluster which has openssl:

```
echo | openssl s_client -showcerts -connect kubernetes.default.svc:443 2> /dev/null | openssl x509 -noout -text | grep DNS
```