### PR TITLE
Add more kubernetes operations

### DIFF
--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesOperations.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesOperations.java
@@ -27,6 +27,7 @@ import io.micronaut.kubernetes.client.v1.endpoints.EndpointsList;
 import io.micronaut.kubernetes.client.v1.pods.Pod;
 import io.micronaut.kubernetes.client.v1.secrets.Secret;
 import io.micronaut.kubernetes.client.v1.secrets.SecretList;
+import io.micronaut.kubernetes.client.v1.secrets.SecretWatchEvent;
 import io.micronaut.kubernetes.client.v1.services.Service;
 import io.micronaut.kubernetes.client.v1.services.ServiceList;
 import org.reactivestreams.Publisher;
@@ -132,6 +133,18 @@ public interface KubernetesOperations {
      */
     @Get("/namespaces/{namespace}/secrets?labelSelector={labelSelector}")
     Publisher<SecretList> listSecrets(String namespace, @Nullable String labelSelector);
+
+    /**
+     * Watch objects of kind Secret.
+     *
+     * @param namespace object name and auth scope, such as for teams and projects
+     * @param resourceVersion the resource version to receive events from. If set to 0, Kubernetes will send all events
+     * @param labelSelector A selector to restrict the list of returned objects by their labels
+     * @return a {@link ConfigMapList}
+     */
+    @Get("/watch/namespaces/{namespace}/secrets?resourceVersion={resourceVersion}&labelSelector={labelSelector}")
+    @Consumes(value = {MediaType.APPLICATION_JSON_STREAM, MediaType.APPLICATION_JSON})
+    Publisher<SecretWatchEvent> watchSecrets(String namespace, Long resourceVersion, @Nullable String labelSelector);
 
     /**
      * @param namespace object name and auth scope, such as for teams and projects

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesOperations.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesOperations.java
@@ -24,6 +24,7 @@ import io.micronaut.http.annotation.Consumes;
 import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Put;
 import io.micronaut.kubernetes.client.v1.configmaps.ConfigMap;
 import io.micronaut.kubernetes.client.v1.configmaps.ConfigMapList;
 import io.micronaut.kubernetes.client.v1.configmaps.ConfigMapWatchEvent;
@@ -139,6 +140,17 @@ public interface KubernetesOperations {
     Publisher<ConfigMap> createConfigMap(String namespace, @Body ConfigMap configMap);
 
     /**
+     * Replace the specified ConfigMap.
+     *
+     * @param namespace object name and auth scope, such as for teams and projects
+     * @param configMapName name of the ConfigMap
+     * @param configMap to replace
+     * @return a {@link ConfigMap}
+     */
+    @Put("/namespaces/{namespace}/configmaps/{configMapName}")
+    Publisher<ConfigMap> replaceConfigMap(String namespace, String configMapName, @Body ConfigMap configMap);
+
+    /**
      * Delete the specified ConfigMap.
      *
      * @param namespace     object name and auth scope, such as for teams and projects
@@ -198,6 +210,17 @@ public interface KubernetesOperations {
     Publisher<Secret> createSecret(String namespace, @Body Secret secret);
 
     /**
+     * Replace the specified Secret.
+     *
+     * @param namespace object name and auth scope, such as for teams and projects
+     * @param secretName the secret name
+     * @param secret    the secret to replace
+     * @return A {@link Secret} instance
+     */
+    @Put("/namespaces/{namespace}/secrets/{secretName}")
+    Publisher<Secret> replaceSecret(String namespace, String secretName, @Body Secret secret);
+
+    /**
      * Delete the specified Secret.
      *
      * @param namespace  object name and auth scope, such as for teams and projects
@@ -211,7 +234,7 @@ public interface KubernetesOperations {
      * Returns a {@link Pod} of the given name in the given namespace.
      * @param namespace object name and auth scope, such as for teams and projects
      * @param podName the pod name
-     * @return A {@Pod} instance
+     * @return A {@link Pod} instance
      */
     @Get("/namespaces/{namespace}/pods/{podName}")
     Publisher<Pod> getPod(String namespace, String podName);
@@ -238,7 +261,7 @@ public interface KubernetesOperations {
      * Returns the created {@link Pod} in the given namespace.
      * @param namespace object name and auth scope, such as for teams and projects
      * @param pod the pod to create
-     * @return A {@Pod} instance
+     * @return A {@link Pod} instance
      */
     @Post("/namespaces/{namespace}/pods")
     Publisher<Pod> createPod(String namespace, @Body Pod pod);
@@ -248,7 +271,7 @@ public interface KubernetesOperations {
      *
      * @param namespace object name and auth scope, such as for teams and projects
      * @param podName   the pod name
-     * @return A {@Pod} instance
+     * @return A {@link Pod} instance
      */
     @Delete("/namespaces/{namespace}/pods/{podName}")
     Publisher<Pod> deletePod(String namespace, String podName);

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesOperations.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesOperations.java
@@ -16,8 +16,11 @@
 
 package io.micronaut.kubernetes.client.v1;
 
+import javax.annotation.Nullable;
+
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Consumes;
+import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.kubernetes.client.v1.configmaps.ConfigMap;
 import io.micronaut.kubernetes.client.v1.configmaps.ConfigMapList;
@@ -31,8 +34,6 @@ import io.micronaut.kubernetes.client.v1.secrets.SecretWatchEvent;
 import io.micronaut.kubernetes.client.v1.services.Service;
 import io.micronaut.kubernetes.client.v1.services.ServiceList;
 import org.reactivestreams.Publisher;
-
-import javax.annotation.Nullable;
 
 /**
  * Defines the HTTP requests to query the Kubernetes API.
@@ -125,9 +126,29 @@ public interface KubernetesOperations {
     Publisher<ConfigMap> getConfigMap(String namespace, String configMapName);
 
     /**
-     * List objects of kind Secret.
+     * Create the specified ConfigMap.
      *
      * @param namespace object name and auth scope, such as for teams and projects
+     * @param configMap to create
+     * @return a {@link ConfigMap}
+     */
+    @Post("/namespaces/{namespace}/configmaps")
+    Publisher<ConfigMap> createConfigMap(String namespace, @Body ConfigMap configMap);
+
+    /**
+     * Delete the specified ConfigMap.
+     *
+     * @param namespace     object name and auth scope, such as for teams and projects
+     * @param configMapName name of the ConfigMap
+     * @return a {@link ConfigMap}
+     */
+    @Delete("/namespaces/{namespace}/configmaps/{configMapName}")
+    Publisher<ConfigMap> deleteConfigMap(String namespace, String configMapName);
+
+    /**
+     * List objects of kind Secret.
+     *
+     * @param namespace     object name and auth scope, such as for teams and projects
      * @param labelSelector A selector to restrict the list of returned objects by their labels
      * @return a {@link SecretList}
      */
@@ -162,6 +183,26 @@ public interface KubernetesOperations {
      */
     @Get("/namespaces/{namespace}/secrets/{secretName}")
     Publisher<Secret> getSecret(String namespace, String secretName);
+
+    /**
+     * Create the specified Secret.
+     *
+     * @param namespace object name and auth scope, such as for teams and projects
+     * @param secret    the secret
+     * @return A {@link Secret} instance
+     */
+    @Post("/namespaces/{namespace}/secrets/")
+    Publisher<Secret> createSecret(String namespace, @Body Secret secret);
+
+    /**
+     * Delete the specified Secret.
+     *
+     * @param namespace  object name and auth scope, such as for teams and projects
+     * @param secretName the secret name
+     * @return A {@link Secret} instance
+     */
+    @Delete("/namespaces/{namespace}/secrets/{secretName}")
+    Publisher<Secret> deleteSecret(String namespace, String secretName);
 
     /**
      * Returns a {@link Pod} of the given name in the given namespace.

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesOperations.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesOperations.java
@@ -19,15 +19,18 @@ package io.micronaut.kubernetes.client.v1;
 import javax.annotation.Nullable;
 
 import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Consumes;
 import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
 import io.micronaut.kubernetes.client.v1.configmaps.ConfigMap;
 import io.micronaut.kubernetes.client.v1.configmaps.ConfigMapList;
 import io.micronaut.kubernetes.client.v1.configmaps.ConfigMapWatchEvent;
 import io.micronaut.kubernetes.client.v1.endpoints.Endpoints;
 import io.micronaut.kubernetes.client.v1.endpoints.EndpointsList;
 import io.micronaut.kubernetes.client.v1.pods.Pod;
+import io.micronaut.kubernetes.client.v1.pods.PodList;
 import io.micronaut.kubernetes.client.v1.secrets.Secret;
 import io.micronaut.kubernetes.client.v1.secrets.SecretList;
 import io.micronaut.kubernetes.client.v1.secrets.SecretWatchEvent;
@@ -213,4 +216,40 @@ public interface KubernetesOperations {
     @Get("/namespaces/{namespace}/pods/{podName}")
     Publisher<Pod> getPod(String namespace, String podName);
 
+    /**
+     * List pods in the given namespace.
+     *
+     * @param namespace     Object name and auth scope, such as for teams and projects
+     * @param labelSelector A selector to restrict the list of returned objects by their labels
+     * @return a {@link PodList} of the given namespace
+     */
+    @Get("/namespaces/{namespace}/pods?labelSelector={labelSelector}")
+    Publisher<PodList> listPods(String namespace, @Nullable String labelSelector);
+
+    /**
+     * @param namespace object name and auth scope, such as for teams and projects
+     * @return a {@link PodList} of the given namespace
+     */
+    default Publisher<PodList> listPods(String namespace) {
+        return listPods(namespace, null);
+    }
+
+    /**
+     * Returns the created {@link Pod} in the given namespace.
+     * @param namespace object name and auth scope, such as for teams and projects
+     * @param pod the pod to create
+     * @return A {@Pod} instance
+     */
+    @Post("/namespaces/{namespace}/pods")
+    Publisher<Pod> createPod(String namespace, @Body Pod pod);
+
+    /**
+     * Returns the deleted {@link Pod} in the given namespace.
+     *
+     * @param namespace object name and auth scope, such as for teams and projects
+     * @param podName   the pod name
+     * @return A {@Pod} instance
+     */
+    @Delete("/namespaces/{namespace}/pods/{podName}")
+    Publisher<Pod> deletePod(String namespace, String podName);
 }

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/LocalObjectReference.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/LocalObjectReference.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.kubernetes.client.v1;
+
+import io.micronaut.core.annotation.Introspected;
+
+/**
+ * LocalObjectReference.
+ *
+ * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#localobjectreference-v1-core">LocalObjectReference v1 core</a>
+ *
+ * @author <Miguel Ferreira>
+ */
+@Introspected
+public class LocalObjectReference {
+
+    private String name;
+
+    /**
+     * @return the name of the object.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name of the object.
+     */
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "LocalObjectReference{" +
+                "name='" + name + '\'' +
+                '}';
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/ConfigMapEnvSource.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/ConfigMapEnvSource.java
@@ -17,54 +17,50 @@
 package io.micronaut.kubernetes.client.v1.pods;
 
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.kubernetes.client.v1.KubernetesObject;
 
 /**
- * Represents a Kubernetes Pod.
+ * A source of environment variables for a container backed by a ConfigMap.
  *
- * @author Álvaro Sánchez-Mariscal
- * @since 1.0.0
+ * @author <Miguel Ferreira>
  */
 @Introspected
-public class Pod extends KubernetesObject {
-
-    private PodStatus status;
-    private PodSpec spec;
+public class ConfigMapEnvSource {
+    private String name;
+    private boolean optional;
 
     /**
-     * @return pod status information
+     * @return the name of the ConfigMap
      */
-    public PodStatus getStatus() {
-        return status;
+    public String getName() {
+        return name;
     }
 
     /**
-     * @param podStatus pod status information
+     * @param name the name of the ConfigMap
      */
-    public void setStatus(PodStatus podStatus) {
-        this.status = podStatus;
+    public void setName(final String name) {
+        this.name = name;
     }
 
     /**
-     * @return The specification of the desired behavior of the pod
+     * @return Whether the ConfigMap must be defined
      */
-    public PodSpec getSpec() {
-        return spec;
+    public boolean isOptional() {
+        return optional;
     }
 
     /**
-     * @param spec The specification of the desired behavior of the pod
+     * @param optional Specifies whether the ConfigMap must be defined
      */
-    public void setSpec(final PodSpec spec) {
-        this.spec = spec;
+    public void setOptional(final boolean optional) {
+        this.optional = optional;
     }
 
     @Override
     public String toString() {
-        return "Pod{" +
-                "metadata=" + getMetadata() +
-                ", status=" + status +
-                ", spec=" + spec +
+        return "ConfigMapEnvSource{" +
+                "name='" + name + '\'' +
+                ", optional=" + optional +
                 '}';
     }
 }

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/ConfigMapVolumeSource.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/ConfigMapVolumeSource.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.kubernetes.client.v1.pods;
+
+import java.util.List;
+
+import io.micronaut.core.annotation.Introspected;
+
+/**
+ * A source of content for a container volume backed by a ConfigMap.
+ *
+ * @author <Miguel Ferreira>
+ */
+@Introspected
+public class ConfigMapVolumeSource {
+
+    private String name;
+    private boolean optional;
+    private int defaultMode;
+    private List<KeyToPath> items;
+
+    /**
+     * @return Name of the ConfigMap in the pod's namespace to use.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name Name of the ConfigMap in the pod's namespace to use.
+     */
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return Specifies whether the ConfigMap or its keys must be defined
+     */
+    public boolean isOptional() {
+        return optional;
+    }
+
+    /**
+     * @param optional Whether the ConfigMap or its keys must be defined
+     */
+    public void setOptional(final boolean optional) {
+        this.optional = optional;
+    }
+
+    /**
+     * @return Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting.
+     */
+    public int getDefaultMode() {
+        return defaultMode;
+    }
+
+    /**
+     * @param defaultMode Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting.
+     */
+    public void setDefaultMode(final int defaultMode) {
+        this.defaultMode = defaultMode;
+    }
+
+    /**
+     * @return If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+     */
+    public List<KeyToPath> getItems() {
+        return items;
+    }
+
+    /**
+     * @param items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+     */
+    public void setItems(final List<KeyToPath> items) {
+        this.items = items;
+    }
+
+    @Override
+    public String toString() {
+        return "ConfigMapVolumeSource{" +
+                "name='" + name + '\'' +
+                ", optional=" + optional +
+                ", defaultMode=" + defaultMode +
+                ", items=" + items +
+                '}';
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/Container.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/Container.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.kubernetes.client.v1.pods;
+
+import java.util.List;
+
+import io.micronaut.core.annotation.Introspected;
+
+/**
+ * Represents a container.
+ *
+ * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">Container v1 core</a>.
+ *
+ * @author <Miguel Ferreira>
+ */
+@Introspected
+public class Container {
+
+    private String name;
+    private List<String> args;
+    private List<String> command;
+    private List<EnvVar> env;
+    private List<EnvFromSource> envFrom;
+    private String image;
+    private String imagePullPolicy;
+    private List<VolumeMount> volumeMounts;
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name
+     */
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return Arguments to the entrypoint.
+     */
+    public List<String> getArgs() {
+        return args;
+    }
+
+    /**
+     * @param args Arguments to the entrypoint.
+     */
+    public void setArgs(final List<String> args) {
+        this.args = args;
+    }
+
+    /**
+     * @return Entrypoint array. The commands that are executed.
+     */
+    public List<String> getCommand() {
+        return command;
+    }
+
+    /**
+     * @param command Entrypoint array. The commands that are executed.
+     */
+    public void setCommand(final List<String> command) {
+        this.command = command;
+    }
+
+    /**
+     * @return List of environment variables to set in the container.
+     */
+    public List<EnvVar> getEnv() {
+        return env;
+    }
+
+    /**
+     * @param env List of environment variables to set in the container.
+     */
+    public void setEnv(final List<EnvVar> env) {
+        this.env = env;
+    }
+
+    /**
+     * @return List of sources to populate environment variables in the container.
+     */
+    public List<EnvFromSource> getEnvFrom() {
+        return envFrom;
+    }
+
+    /**
+     * @param envFrom List of sources to populate environment variables in the container.
+     */
+    public void setEnvFrom(final List<EnvFromSource> envFrom) {
+        this.envFrom = envFrom;
+    }
+
+    /**
+     * @return Docker image name, including tag
+     */
+    public String getImage() {
+        return image;
+    }
+
+    /**
+     * @param image Docker image name, including tag
+     */
+    public void setImage(final String image) {
+        this.image = image;
+    }
+
+    /**
+     * @return Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise
+     */
+    public String getImagePullPolicy() {
+        return imagePullPolicy;
+    }
+
+    /**
+     * @param imagePullPolicy Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise
+     */
+    public void setImagePullPolicy(final String imagePullPolicy) {
+        this.imagePullPolicy = imagePullPolicy;
+    }
+
+    /**
+     * @return Pod volumes to mount into the container's filesystem
+     */
+    public List<VolumeMount> getVolumeMounts() {
+        return volumeMounts;
+    }
+
+    /**
+     * @param volumeMounts Pod volumes to mount into the container's filesystem
+     */
+    public void setVolumeMounts(final List<VolumeMount> volumeMounts) {
+        this.volumeMounts = volumeMounts;
+    }
+
+    @Override
+    public String toString() {
+        return "Container{" +
+                "name='" + name + '\'' +
+                ", args=" + args +
+                ", command=" + command +
+                ", env=" + env +
+                ", envFrom=" + envFrom +
+                ", image='" + image + '\'' +
+                ", imagePullPolicy='" + imagePullPolicy + '\'' +
+                ", volumeMounts=" + volumeMounts +
+                '}';
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/EmptyDirVolumeSource.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/EmptyDirVolumeSource.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.kubernetes.client.v1.pods;
+
+import io.micronaut.core.annotation.Introspected;
+
+/**
+ * Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.
+ *
+ * @author <Miguel Ferreira>
+ */
+@Introspected
+public class EmptyDirVolumeSource {
+
+    private String medium = "";
+
+    /**
+     * @return What type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory.
+     */
+    public String getMedium() {
+        return medium;
+    }
+
+    /**
+     * @param medium What type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory.
+     */
+    public void setMedium(final String medium) {
+        this.medium = medium;
+    }
+
+    @Override
+    public String toString() {
+        return "EmptyDirVolumeSource{" +
+                "medium='" + medium + '\'' +
+                '}';
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/EnvFromSource.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/EnvFromSource.java
@@ -17,54 +17,50 @@
 package io.micronaut.kubernetes.client.v1.pods;
 
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.kubernetes.client.v1.KubernetesObject;
 
 /**
- * Represents a Kubernetes Pod.
+ * A source of environment variables for a container.
  *
- * @author Álvaro Sánchez-Mariscal
- * @since 1.0.0
+ * @author <Miguel Ferreira>
  */
 @Introspected
-public class Pod extends KubernetesObject {
-
-    private PodStatus status;
-    private PodSpec spec;
+public class EnvFromSource {
+    private ConfigMapEnvSource configMapRef;
+    private SecretEnvSource secretRef;
 
     /**
-     * @return pod status information
+     * @return The ConfigMap to select from
      */
-    public PodStatus getStatus() {
-        return status;
+    public ConfigMapEnvSource getConfigMapRef() {
+        return configMapRef;
     }
 
     /**
-     * @param podStatus pod status information
+     * @param configMapRef The ConfigMap to select from
      */
-    public void setStatus(PodStatus podStatus) {
-        this.status = podStatus;
+    public void setConfigMapRef(final ConfigMapEnvSource configMapRef) {
+        this.configMapRef = configMapRef;
     }
 
     /**
-     * @return The specification of the desired behavior of the pod
+     * @return The Secret to select from
      */
-    public PodSpec getSpec() {
-        return spec;
+    public SecretEnvSource getSecretRef() {
+        return secretRef;
     }
 
     /**
-     * @param spec The specification of the desired behavior of the pod
+     * @param secretRef The Secret to select from
      */
-    public void setSpec(final PodSpec spec) {
-        this.spec = spec;
+    public void setSecretRef(final SecretEnvSource secretRef) {
+        this.secretRef = secretRef;
     }
 
     @Override
     public String toString() {
-        return "Pod{" +
-                "metadata=" + getMetadata() +
-                ", status=" + status +
-                ", spec=" + spec +
+        return "EnvFromSource{" +
+                "configMapRef=" + configMapRef +
+                ", secretRef=" + secretRef +
                 '}';
     }
 }

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/EnvVar.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/EnvVar.java
@@ -17,54 +17,50 @@
 package io.micronaut.kubernetes.client.v1.pods;
 
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.kubernetes.client.v1.KubernetesObject;
 
 /**
- * Represents a Kubernetes Pod.
+ * Environment variable to set in a container.
  *
- * @author Álvaro Sánchez-Mariscal
- * @since 1.0.0
+ * @author <Miguel Ferreira>
  */
 @Introspected
-public class Pod extends KubernetesObject {
-
-    private PodStatus status;
-    private PodSpec spec;
+public class EnvVar {
+    private String name;
+    private String value;
 
     /**
-     * @return pod status information
+     * @return Name of the environment variable.
      */
-    public PodStatus getStatus() {
-        return status;
+    public String getName() {
+        return name;
     }
 
     /**
-     * @param podStatus pod status information
+     * @param name Name of the environment variable.
      */
-    public void setStatus(PodStatus podStatus) {
-        this.status = podStatus;
+    public void setName(final String name) {
+        this.name = name;
     }
 
     /**
-     * @return The specification of the desired behavior of the pod
+     * @return Value of the environment variable.
      */
-    public PodSpec getSpec() {
-        return spec;
+    public String getValue() {
+        return value;
     }
 
     /**
-     * @param spec The specification of the desired behavior of the pod
+     * @param value Value of the environment variable.
      */
-    public void setSpec(final PodSpec spec) {
-        this.spec = spec;
+    public void setValue(final String value) {
+        this.value = value;
     }
 
     @Override
     public String toString() {
-        return "Pod{" +
-                "metadata=" + getMetadata() +
-                ", status=" + status +
-                ", spec=" + spec +
+        return "EnvVar{" +
+                "name='" + name + '\'' +
+                ", value='" + value + '\'' +
                 '}';
     }
 }

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/KeyToPath.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/KeyToPath.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.kubernetes.client.v1.pods;
+
+import io.micronaut.core.annotation.Introspected;
+
+/**
+ * A key-value pair in the Data field of the referenced ConfigMap that will be projected into the volume as a file whose name is the key and content is the value.
+ *
+ * @author <Miguel Ferreira>
+ */
+@Introspected
+public class KeyToPath {
+    private String key;
+    private String path;
+    private Integer mode;
+
+    /**
+     * @return The key to project.
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * @param key The key to project.
+     */
+    public void setKey(final String key) {
+        this.key = key;
+    }
+
+    /**
+     * @return The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * @param path The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+     */
+    public void setPath(final String path) {
+        this.path = path;
+    }
+
+    /**
+     * @return Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+     */
+    public Integer getMode() {
+        return mode;
+    }
+
+    /**
+     * @param mode Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+     */
+    public void setMode(final Integer mode) {
+        this.mode = mode;
+    }
+
+    @Override
+    public String toString() {
+        return "KeyToPath{" +
+                "key='" + key + '\'' +
+                ", path='" + path + '\'' +
+                ", mode=" + mode +
+                '}';
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/PodList.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/PodList.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.kubernetes.client.v1.pods;
+
+import java.util.Collections;
+import java.util.List;
+
+import io.micronaut.core.annotation.Introspected;
+
+/**
+ * Represents a response of type <code>PodList</code> from the Kubernetes API.
+ *
+ * @author <Miguel Ferreira>
+ */
+@Introspected
+public class PodList {
+
+    private List<Pod> items;
+
+    /**
+     * @return The items
+     */
+    public List<Pod> getItems() {
+        if (items == null) {
+            return Collections.emptyList();
+        }
+        return items;
+    }
+
+    /**
+     * @param items The items
+     */
+    public void setItems(List<Pod> items) {
+        this.items = items;
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/PodSpec.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/PodSpec.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.kubernetes.client.v1.pods;
+
+import java.util.List;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.kubernetes.client.v1.LocalObjectReference;
+
+/**
+ * Specification of the desired behavior of the pod.
+ *
+ * @author Miguel Ferreira
+ * @since 1.0.5
+ */
+@Introspected
+public class PodSpec {
+
+    private String restartPolicy;
+    private String serviceAccountName;
+    private List<Container> containers;
+    private List<Container> initContainers;
+    private List<Volume> volumes;
+    private List<LocalObjectReference> imagePullSecrets;
+
+    /**
+     * @return Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always.
+     */
+    public String getRestartPolicy() {
+        return restartPolicy;
+    }
+
+    /**
+     * @param restartPolicy Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always.
+     */
+    public void setRestartPolicy(final String restartPolicy) {
+        this.restartPolicy = restartPolicy;
+    }
+
+    /**
+     * @return ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+     */
+    public String getServiceAccountName() {
+        return serviceAccountName;
+    }
+
+    /**
+     * @param serviceAccountName ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+     */
+    public void setServiceAccountName(final String serviceAccountName) {
+        this.serviceAccountName = serviceAccountName;
+    }
+
+    /**
+     * @return List of containers belonging to the pod.
+     */
+    public List<Container> getContainers() {
+        return containers;
+    }
+
+    /**
+     * @param containers List of containers belonging to the pod.
+     */
+    public void setContainers(final List<Container> containers) {
+        this.containers = containers;
+    }
+
+    /**
+     * @return List of initialization containers belonging to the pod.
+     */
+    public List<Container> getInitContainers() {
+        return initContainers;
+    }
+
+    /**
+     * @param initContainers List of initialization containers belonging to the pod.
+     */
+    public void setInitContainers(final List<Container> initContainers) {
+        this.initContainers = initContainers;
+    }
+
+    /**
+     * @return List of volumes that can be mounted by containers belonging to the pod.
+     */
+    public List<Volume> getVolumes() {
+        return volumes;
+    }
+
+    /**
+     * @param volumes List of volumes that can be mounted by containers belonging to the pod.
+     */
+    public void setVolumes(final List<Volume> volumes) {
+        this.volumes = volumes;
+    }
+
+    /**
+     * @return ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+     */
+    public List<LocalObjectReference> getImagePullSecrets() {
+        return imagePullSecrets;
+    }
+
+    /**
+     * @param imagePullSecrets ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+     */
+    public void setImagePullSecrets(final List<LocalObjectReference> imagePullSecrets) {
+        this.imagePullSecrets = imagePullSecrets;
+    }
+
+    @Override
+    public String toString() {
+        return "PodSpec{" +
+                "restartPolicy='" + restartPolicy + '\'' +
+                ", serviceAccountName='" + serviceAccountName + '\'' +
+                ", containers=" + containers +
+                ", initContainers=" + initContainers +
+                ", volumes=" + volumes +
+                ", imagePullSecrets=" + imagePullSecrets +
+                '}';
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/SecretEnvSource.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/SecretEnvSource.java
@@ -17,54 +17,50 @@
 package io.micronaut.kubernetes.client.v1.pods;
 
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.kubernetes.client.v1.KubernetesObject;
 
 /**
- * Represents a Kubernetes Pod.
+ * A source of environment variables for a container backed by a Secret.
  *
- * @author Álvaro Sánchez-Mariscal
- * @since 1.0.0
+ * @author <Miguel Ferreira>
  */
 @Introspected
-public class Pod extends KubernetesObject {
-
-    private PodStatus status;
-    private PodSpec spec;
+public class SecretEnvSource {
+    private String name;
+    private boolean optional;
 
     /**
-     * @return pod status information
+     * @return Name of the referent.
      */
-    public PodStatus getStatus() {
-        return status;
+    public String getName() {
+        return name;
     }
 
     /**
-     * @param podStatus pod status information
+     * @param name Name of the referent.
      */
-    public void setStatus(PodStatus podStatus) {
-        this.status = podStatus;
+    public void setName(final String name) {
+        this.name = name;
     }
 
     /**
-     * @return The specification of the desired behavior of the pod
+     * @return Specifies whether the Secret must be defined
      */
-    public PodSpec getSpec() {
-        return spec;
+    public boolean isOptional() {
+        return optional;
     }
 
     /**
-     * @param spec The specification of the desired behavior of the pod
+     * @param optional Whether the Secret must be defined
      */
-    public void setSpec(final PodSpec spec) {
-        this.spec = spec;
+    public void setOptional(final boolean optional) {
+        this.optional = optional;
     }
 
     @Override
     public String toString() {
-        return "Pod{" +
-                "metadata=" + getMetadata() +
-                ", status=" + status +
-                ", spec=" + spec +
+        return "SecretEnvSource{" +
+                "name='" + name + '\'' +
+                ", optional=" + optional +
                 '}';
     }
 }

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/SecretVolumeSource.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/SecretVolumeSource.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.kubernetes.client.v1.pods;
+
+import java.util.List;
+
+import io.micronaut.core.annotation.Introspected;
+
+/**
+ * A source of content for a container volume backed by a Secret.
+ *
+ * @author <Miguel Ferreira>
+ */
+@Introspected
+public class SecretVolumeSource {
+
+    private String secretName;
+    private boolean optional;
+    private int defaultMode;
+    private List<KeyToPath> items;
+
+    /**
+     * @return Name of the secret in the pod's namespace to use.
+     */
+    public String getSecretName() {
+        return secretName;
+    }
+
+    /**
+     * @param secretName Name of the secret in the pod's namespace to use.
+     */
+    public void setSecretName(final String secretName) {
+        this.secretName = secretName;
+    }
+
+    /**
+     * @return Specifies whether the Secret or its keys must be defined
+     */
+    public boolean isOptional() {
+        return optional;
+    }
+
+    /**
+     * @param optional Whether the Secret or its keys must be defined
+     */
+    public void setOptional(final boolean optional) {
+        this.optional = optional;
+    }
+
+    /**
+     * @return Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting.
+     */
+    public int getDefaultMode() {
+        return defaultMode;
+    }
+
+    /**
+     * @param defaultMode Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting.
+     */
+    public void setDefaultMode(final int defaultMode) {
+        this.defaultMode = defaultMode;
+    }
+
+    /**
+     * @return If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+     */
+    public List<KeyToPath> getItems() {
+        return items;
+    }
+
+    /**
+     * @param items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+     */
+    public void setItems(final List<KeyToPath> items) {
+        this.items = items;
+    }
+
+    @Override
+    public String toString() {
+        return "SecretVolumeSource{" +
+                "secretName='" + secretName + '\'' +
+                ", optional=" + optional +
+                ", defaultMode=" + defaultMode +
+                ", items=" + items +
+                '}';
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/Volume.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/Volume.java
@@ -28,6 +28,8 @@ public class Volume {
 
     private String name;
     private SecretVolumeSource secret;
+    private ConfigMapVolumeSource configMap;
+    private EmptyDirVolumeSource emptyDir;
 
     /**
      * @return Volume's name.
@@ -57,11 +59,41 @@ public class Volume {
         this.secret = secret;
     }
 
+    /**
+     * @return ConfigMap that populates this volume.
+     */
+    public ConfigMapVolumeSource getConfigMap() {
+        return configMap;
+    }
+
+    /**
+     * @param configMap ConfigMap that populates this volume.
+     */
+    public void setConfigMap(final ConfigMapVolumeSource configMap) {
+        this.configMap = configMap;
+    }
+
+    /**
+     * @return EmptyDir represents a temporary directory that shares a pod's lifetime.
+     */
+    public EmptyDirVolumeSource getEmptyDir() {
+        return emptyDir;
+    }
+
+    /**
+     * @param emptyDir EmptyDir represents a temporary directory that shares a pod's lifetime.
+     */
+    public void setEmptyDir(final EmptyDirVolumeSource emptyDir) {
+        this.emptyDir = emptyDir;
+    }
+
     @Override
     public String toString() {
         return "Volume{" +
                 "name='" + name + '\'' +
                 ", secret=" + secret +
+                ", configMap=" + configMap +
+                ", emptyDir=" + emptyDir +
                 '}';
     }
 }

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/Volume.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/Volume.java
@@ -17,54 +17,51 @@
 package io.micronaut.kubernetes.client.v1.pods;
 
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.kubernetes.client.v1.KubernetesObject;
 
 /**
- * Represents a Kubernetes Pod.
+ * Volume for pod containers.
  *
- * @author Álvaro Sánchez-Mariscal
- * @since 1.0.0
+ * @author <Miguel Ferreira>
  */
 @Introspected
-public class Pod extends KubernetesObject {
+public class Volume {
 
-    private PodStatus status;
-    private PodSpec spec;
+    private String name;
+    private SecretVolumeSource secret;
 
     /**
-     * @return pod status information
+     * @return Volume's name.
      */
-    public PodStatus getStatus() {
-        return status;
+    public String getName() {
+        return name;
     }
 
     /**
-     * @param podStatus pod status information
+     * @param name Volume's name.
      */
-    public void setStatus(PodStatus podStatus) {
-        this.status = podStatus;
+    public void setName(final String name) {
+        this.name = name;
     }
 
     /**
-     * @return The specification of the desired behavior of the pod
+     * @return Secret that populates this volume.
      */
-    public PodSpec getSpec() {
-        return spec;
+    public SecretVolumeSource getSecret() {
+        return secret;
     }
 
     /**
-     * @param spec The specification of the desired behavior of the pod
+     * @param secret Secret that should populate this volume.
      */
-    public void setSpec(final PodSpec spec) {
-        this.spec = spec;
+    public void setSecret(final SecretVolumeSource secret) {
+        this.secret = secret;
     }
 
     @Override
     public String toString() {
-        return "Pod{" +
-                "metadata=" + getMetadata() +
-                ", status=" + status +
-                ", spec=" + spec +
+        return "Volume{" +
+                "name='" + name + '\'' +
+                ", secret=" + secret +
                 '}';
     }
 }

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/VolumeMount.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/pods/VolumeMount.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.kubernetes.client.v1.pods;
+
+import io.micronaut.core.annotation.Introspected;
+
+
+/**
+ * VolumeMount describes a mounting of a Volume within a container.
+ *
+ * @author <Miguel Ferreira>
+ */
+@Introspected
+public class VolumeMount {
+    private String name;
+    private String mountPath;
+
+    /**
+     * @return This must match the Name of a Volume.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name This must match the Name of a Volume.
+     */
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return Path within the container at which the volume should be mounted. Must not contain ':'.
+     */
+    public String getMountPath() {
+        return mountPath;
+    }
+
+    /**
+     * @param mountPath Path within the container at which the volume should be mounted. Must not contain ':'.
+     */
+    public void setMountPath(final String mountPath) {
+        this.mountPath = mountPath;
+    }
+
+    @Override
+    public String toString() {
+        return "VolumeMount{" +
+                "name='" + name + '\'' +
+                ", mountPath='" + mountPath + '\'' +
+                '}';
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/secrets/Secret.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/secrets/Secret.java
@@ -19,8 +19,10 @@ package io.micronaut.kubernetes.client.v1.secrets;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.kubernetes.client.v1.KubernetesObject;
 
+import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Kubernetes secret objects let you store and manage sensitive information, such as passwords, OAuth tokens, and ssh keys.
@@ -33,7 +35,7 @@ public class Secret extends KubernetesObject {
 
     public static final String OPAQUE_SECRET_TYPE = "Opaque";
 
-    private Map<String, String> data = new HashMap<>();
+    private Map<String, byte[]> data = new HashMap<>();
     private String type;
 
     /**
@@ -41,7 +43,7 @@ public class Secret extends KubernetesObject {
      * serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string)
      * data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
      */
-    public Map<String, String> getData() {
+    public Map<String, byte[]> getData() {
         return data;
     }
 
@@ -50,7 +52,7 @@ public class Secret extends KubernetesObject {
      * serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string)
      * data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
      */
-    public void setData(Map<String, String> data) {
+    public void setData(Map<String, byte[]> data) {
         this.data = data;
     }
 
@@ -66,6 +68,14 @@ public class Secret extends KubernetesObject {
      */
     public void setType(String type) {
         this.type = type;
+    }
+
+    /**
+     * @return The secret data with the values converted to string
+     */
+    public Map<String, String> getStringData() {
+        return data.entrySet().stream()
+                   .collect(Collectors.toMap(Map.Entry::getKey, e -> new String(e.getValue())));
     }
 
     @Override

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/secrets/SecretWatchEvent.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/secrets/SecretWatchEvent.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.kubernetes.client.v1.secrets;
+
+import io.micronaut.core.annotation.Introspected;
+
+/**
+ * Represents a Secret watch event returned from the Kubernetes API.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 1.0.0
+ */
+@Introspected
+public class SecretWatchEvent {
+
+    private EventType type;
+    private Secret object;
+
+    /**
+     * The default constructor.
+     */
+    public SecretWatchEvent() {
+    }
+
+    /**
+     * @param type the event type
+     */
+    public SecretWatchEvent(EventType type) {
+        this.type = type;
+    }
+
+    /**
+     * @return the {@link EventType}
+     */
+    public EventType getType() {
+        return type;
+    }
+
+    /**
+     * @param type the {@link EventType}
+     */
+    public void setType(EventType type) {
+        this.type = type;
+    }
+
+    /**
+     * @return the {@link Secret} object
+     */
+    public Secret getObject() {
+        return object;
+    }
+
+    /**
+     * @param object the {@link Secret} object
+     */
+    public void setObject(Secret object) {
+        this.object = object;
+    }
+
+    /**
+     * The type of the event occurred.
+     */
+    public enum EventType {
+        ADDED, MODIFIED, DELETED, ERROR
+    }
+
+    @Override
+    public String toString() {
+        return "SecretWatchEvent{" +
+                "type=" + type +
+                ", object=" + object +
+                '}';
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesUtils.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesUtils.java
@@ -118,10 +118,10 @@ public class KubernetesUtils {
             LOG.trace("Processing PropertySources for Secret: {}", secret);
         }
         String name = secret.getMetadata().getName() + KubernetesConfigurationClient.KUBERNETES_SECRET_NAME_SUFFIX;
-        Map<String, String> data = secret.getData();
+        Map<String, String> data = secret.getStringData();
         Map<String, Object> propertySourceData = data.entrySet()
                 .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> decodeSecret(e.getValue())));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         int priority = EnvironmentPropertySource.POSITION + 100;
         PropertySource propertySource = PropertySource.of(name, propertySourceData, priority);
         KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
@@ -170,9 +170,5 @@ public class KubernetesUtils {
         return Optional.of(filename)
                 .filter(f -> f.contains("."))
                 .map(f -> f.substring(filename.lastIndexOf(".") + 1));
-    }
-
-    private static String decodeSecret(String secretValue) {
-        return new String(Base64.getDecoder().decode(secretValue));
     }
 }


### PR DESCRIPTION
This PR adds a few more kubernetes operations:

- create ConfigMap
- delete ConfigMap
- replace ConfigMap
- create Secret
- delete Secret
- replace Secret
- watch Secret
- create Pod
- delete Pod
- list Pod

The implementation of the create secret operation lead to changing the type of the data field in secret from `Map<String, String>` to `Map<String, byte[]>`. That change broke a few tests that read secrets because it was no longer required to base64 decode the values of data.

The implementation of the pod operations lead to just enough modelling of PodSpec to make it possible to run pods with containers, init containers, limited support for volumes, and a couple of environment variable sources.