### PR TITLE
feat: support for GraalVM

### DIFF
--- a/kubernetes-discovery-client/build.gradle
+++ b/kubernetes-discovery-client/build.gradle
@@ -1,9 +1,11 @@
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java"
+    annotationProcessor "io.micronaut:micronaut-graal"
     annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:1.0.22"
 
     compileOnly "io.micronaut:micronaut-inject-java"
     compileOnly "io.micronaut:micronaut-management"
+    compileOnly "org.graalvm.nativeimage:svm"
 
     implementation "io.micronaut:micronaut-discovery-client"
     implementation "io.micronaut:micronaut-runtime"


### PR DESCRIPTION
Because all client object already had @Introspected, we only need to autogenerate reflection-config.json and native-image.properties

Closes #107 