### PR TITLE
Get pod health on healthcheck request

### DIFF
--- a/kubernetes-discovery-client/src/test/resources/k8s/example-client-deployment.yml
+++ b/kubernetes-discovery-client/src/test/resources/k8s/example-client-deployment.yml
@@ -23,3 +23,17 @@ spec:
               containerPort: 8082
             - name: "jvm-debug"
               containerPort: 5005
+          livenessProbe:
+            httpGet:
+              port: 8082
+              path: /health/liveness
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              port: 8082
+              path: /health/readiness
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            failureThreshold: 10

--- a/kubernetes-discovery-client/src/test/resources/k8s/example-service-deployment.yml
+++ b/kubernetes-discovery-client/src/test/resources/k8s/example-service-deployment.yml
@@ -28,6 +28,20 @@ spec:
               containerPort: 8081
             - name: "jvm-debug"
               containerPort: 5004
+          livenessProbe:
+            httpGet:
+              port: 8081
+              path: /health/liveness
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              port: 8081
+              path: /health/readiness
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            failureThreshold: 10
       volumes:
         - name: secrets
           secret:


### PR DESCRIPTION
If the readiness probe is configured then the KubernetesHealthIndicator's
healthInformation contains container status with ready=false forever. This
is because the healthInformation are populated from the constructor,
on container startup when it's not ready yet. This is fixed by updating
the healthInformation on every request of health endpoint.