### PR TITLE
Fix configmap volume

### DIFF
--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesConfiguration.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesConfiguration.java
@@ -17,8 +17,6 @@ package io.micronaut.kubernetes.client.v1;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.ConfigurationProperties;
-import io.micronaut.context.annotation.Requires;
-import io.micronaut.context.env.Environment;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.discovery.DiscoveryConfiguration;
 import io.micronaut.http.client.HttpClientConfiguration;
@@ -42,7 +40,6 @@ import java.util.Map;
  * @author Álvaro Sánchez-Mariscal
  * @since 1.0.0
  */
-@Requires(env = Environment.KUBERNETES)
 @ConfigurationProperties(KubernetesConfiguration.PREFIX)
 @BootstrapContextCompatible
 public class KubernetesConfiguration extends HttpClientConfiguration {
@@ -66,7 +63,7 @@ public class KubernetesConfiguration extends HttpClientConfiguration {
     private boolean secure = KUBERNETES_DEFAULT_SECURE;
     private String namespace;
 
-    private KubernetesConnectionPoolConfiguration connectionPoolConfiguration = new KubernetesConnectionPoolConfiguration();
+    private final KubernetesConnectionPoolConfiguration connectionPoolConfiguration = new KubernetesConnectionPoolConfiguration();
     private KubernetesDiscoveryConfiguration discovery = new KubernetesDiscoveryConfiguration();
     private KubernetesSecretsConfiguration secrets = new KubernetesSecretsConfiguration();
     private KubernetesConfigMapsConfiguration configMaps = new KubernetesConfigMapsConfiguration();

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesConfiguration.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/KubernetesConfiguration.java
@@ -256,6 +256,7 @@ public class KubernetesConfiguration extends HttpClientConfiguration {
         private Collection<String> excludes = new HashSet<>();
         private Map<String, String> labels;
         private List<String> podLabels;
+        private Collection<String> paths;
 
         /**
          * @return the names to include
@@ -318,34 +319,6 @@ public class KubernetesConfiguration extends HttpClientConfiguration {
         public void setPodLabels(List<String> podLabels) {
             this.podLabels = podLabels;
         }
-    }
-
-    /**
-     * Kubernetes secrets configuration properties.
-     */
-    @ConfigurationProperties(KubernetesSecretsConfiguration.PREFIX)
-    @BootstrapContextCompatible
-    public static class KubernetesSecretsConfiguration extends AbstractKubernetesConfiguration {
-
-        static final String PREFIX = "secrets";
-
-        static final boolean DEFAULT_ENABLED = false;
-
-        private boolean enabled = DEFAULT_ENABLED;
-        private Collection<String> paths;
-        private boolean useApi;
-
-        @Override
-        public boolean isEnabled() {
-            return enabled;
-        }
-
-        /**
-         * @param enabled enabled flag.
-         */
-        public void setEnabled(boolean enabled) {
-            this.enabled = enabled;
-        }
 
         /**
          * @return paths where secrets are mounted
@@ -362,6 +335,33 @@ public class KubernetesConfiguration extends HttpClientConfiguration {
          */
         public void setPaths(Collection<String> paths) {
             this.paths = paths;
+        }
+    }
+
+    /**
+     * Kubernetes secrets configuration properties.
+     */
+    @ConfigurationProperties(KubernetesSecretsConfiguration.PREFIX)
+    @BootstrapContextCompatible
+    public static class KubernetesSecretsConfiguration extends AbstractKubernetesConfiguration {
+
+        public static final String PREFIX = "secrets";
+
+        static final boolean DEFAULT_ENABLED = false;
+
+        private boolean enabled = DEFAULT_ENABLED;
+        private boolean useApi;
+
+        @Override
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        /**
+         * @param enabled enabled flag.
+         */
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
         }
 
         /**

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigurationClient.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigurationClient.java
@@ -40,11 +40,16 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static io.micronaut.kubernetes.client.v1.secrets.Secret.OPAQUE_SECRET_TYPE;
 import static io.micronaut.kubernetes.util.KubernetesUtils.computePodLabelSelector;
+import static io.micronaut.kubernetes.util.KubernetesUtils.configMapAsPropertySource;
 
 /**
  * A {@link ConfigurationClient} implementation that provides {@link PropertySource}s read from Kubernetes ConfigMap's.
@@ -65,7 +70,7 @@ public class KubernetesConfigurationClient implements ConfigurationClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesConfigurationClient.class);
 
-    private static Map<String, PropertySource> propertySources = new ConcurrentHashMap<>();
+    private static final Map<String, PropertySource> propertySources = new ConcurrentHashMap<>();
 
     private final KubernetesClient client;
     private final KubernetesConfiguration configuration;
@@ -80,33 +85,6 @@ public class KubernetesConfigurationClient implements ConfigurationClient {
         }
         this.client = client;
         this.configuration = configuration;
-    }
-
-    /**
-     * Retrieves all of the {@link PropertySource} registrations for the given environment.
-     *
-     * @param environment The environment
-     * @return A {@link Publisher} that emits zero or many {@link PropertySource} instances discovered for the given environment
-     */
-    @Override
-    public Publisher<PropertySource> getPropertySources(Environment environment) {
-        if (!propertySources.isEmpty()) {
-            LOG.trace("Found cached PropertySources. Returning them");
-            return Flowable.fromIterable(propertySources.values());
-        } else {
-            LOG.trace("PropertySource cache is empty");
-            return getPropertySourcesFromConfigMaps().mergeWith(getPropertySourcesFromSecrets());
-        }
-    }
-
-    /**
-     * A description that describes this object.
-     *
-     * @return The description
-     */
-    @Override
-    public String getDescription() {
-        return KubernetesClient.SERVICE_ID;
     }
 
     /**
@@ -140,29 +118,106 @@ public class KubernetesConfigurationClient implements ConfigurationClient {
         return propertySources;
     }
 
-    private Flowable<PropertySource> getPropertySourcesFromConfigMaps() {
-        Predicate<KubernetesObject> includesFilter = KubernetesUtils.getIncludesFilter(configuration.getConfigMaps().getIncludes());
-        Predicate<KubernetesObject> excludesFilter = KubernetesUtils.getExcludesFilter(configuration.getConfigMaps().getExcludes());
-        Map<String, String> labels = configuration.getConfigMaps().getLabels();
+    /**
+     * Retrieves all of the {@link PropertySource} registrations for the given environment.
+     *
+     * @param environment The environment
+     * @return A {@link Publisher} that emits zero or many {@link PropertySource} instances discovered for the given environment
+     */
+    @Override
+    public Publisher<PropertySource> getPropertySources(Environment environment) {
+        if (!propertySources.isEmpty()) {
+            LOG.trace("Found cached PropertySources. Returning them");
+            return Flowable.fromIterable(propertySources.values());
+        } else {
+            LOG.trace("PropertySource cache is empty");
+            return getPropertySourcesFromConfigMaps().mergeWith(getPropertySourcesFromSecrets());
+        }
+    }
 
-        return computePodLabelSelector(client, configuration.getConfigMaps().getPodLabels(), configuration.getNamespace(), labels)
-                .flatMap(labelSelector -> client.listConfigMaps(configuration.getNamespace(), labelSelector))
-                .doOnError(throwable -> LOG.error("Error while trying to list all Kubernetes ConfigMaps in the namespace [" + configuration.getNamespace() + "]", throwable))
-                .onErrorReturn(throwable -> new ConfigMapList())
-                .doOnNext(configMapList -> {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Found {} config maps. Applying includes/excludes filters (if any)", configMapList.getItems().size());
-                    }
-                })
-                .flatMapIterable(ConfigMapList::getItems)
-                .filter(includesFilter)
-                .filter(excludesFilter)
-                .doOnNext(configMap -> {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Adding config map with name {}", configMap.getMetadata().getName());
-                    }
-                })
-                .map(KubernetesUtils::configMapAsPropertySource);
+    /**
+     * A description that describes this object.
+     *
+     * @return The description
+     */
+    @Override
+    public String getDescription() {
+        return KubernetesClient.SERVICE_ID;
+    }
+
+    private Flowable<PropertySource> getPropertySourcesFromConfigMaps() {
+
+        Flowable<PropertySource> propertySourceFlowable = Flowable.empty();
+        if (configuration.getSecrets().isEnabled()) {
+            Collection<String> mountedVolumePaths = configuration.getSecrets().getPaths();
+            if (mountedVolumePaths.isEmpty() || configuration.getSecrets().isUseApi()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Reading Secrets from the Kubernetes API");
+                }
+
+
+                Predicate<KubernetesObject> includesFilter = KubernetesUtils.getIncludesFilter(configuration.getConfigMaps().getIncludes());
+                Predicate<KubernetesObject> excludesFilter = KubernetesUtils.getExcludesFilter(configuration.getConfigMaps().getExcludes());
+                Map<String, String> labels = configuration.getConfigMaps().getLabels();
+
+                propertySourceFlowable = propertySourceFlowable.mergeWith(computePodLabelSelector(client, configuration.getConfigMaps().getPodLabels(), configuration.getNamespace(), labels)
+                        .flatMap(labelSelector -> client.listConfigMaps(configuration.getNamespace(), labelSelector))
+                        .doOnError(throwable -> LOG.error("Error while trying to list all Kubernetes ConfigMaps in the namespace [" + configuration.getNamespace() + "]", throwable))
+                        .onErrorReturn(throwable -> new ConfigMapList())
+                        .doOnNext(configMapList -> {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("Found {} config maps. Applying includes/excludes filters (if any)", configMapList.getItems().size());
+                            }
+                        })
+                        .flatMapIterable(ConfigMapList::getItems)
+                        .filter(includesFilter)
+                        .filter(excludesFilter)
+                        .doOnNext(configMap -> {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("Adding config map with name {}", configMap.getMetadata().getName());
+                            }
+                        })
+                        .map(KubernetesUtils::configMapAsPropertySource));
+            }
+            if (!mountedVolumePaths.isEmpty()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Reading configmap from the following mounted volumes: {}", mountedVolumePaths);
+                }
+
+                List<PropertySource> propertySources = new ArrayList<>();
+                mountedVolumePaths.stream()
+                        .map(Paths::get)
+                        .forEach(path -> {
+                            LOG.trace("Processing path: {}", path);
+                            try (DirectoryStream<Path> stream = Files.newDirectoryStream(path)) {
+                                for (Path file : stream) {
+                                    if (!Files.isDirectory(file)) {
+                                        String key = file.getFileName().toString();
+                                        String value = new String(Files.readAllBytes(file));
+                                        if (LOG.isTraceEnabled()) {
+                                            LOG.trace("Processing key: {}", key);
+                                        }
+                                        final HashMap<String, String> objectObjectHashMap = new HashMap();
+                                        objectObjectHashMap.put(key, value);
+                                        final PropertySource propertySource = configMapAsPropertySource(key, objectObjectHashMap);
+                                        addPropertySourceToCache(propertySource);
+                                        propertySources.add(propertySource);
+                                    }
+                                }
+                            } catch (IOException e) {
+                                LOG.warn("Exception occurred when reading configmap from path: {}", path);
+                                LOG.warn(e.getMessage(), e);
+                            }
+                        });
+
+                propertySourceFlowable = propertySourceFlowable.mergeWith(Flowable.fromIterable(propertySources));
+            }
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Kubernetes configmap access is disabled");
+            }
+        }
+        return propertySourceFlowable;
     }
 
     private Flowable<PropertySource> getPropertySourcesFromSecrets() {

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesMountedVolumeConfigurationClient.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesMountedVolumeConfigurationClient.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kubernetes.configuration;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.EnvironmentPropertySource;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.discovery.config.ConfigurationClient;
+import io.micronaut.kubernetes.client.v1.KubernetesClient;
+import io.micronaut.kubernetes.client.v1.KubernetesConfiguration;
+import io.reactivex.Flowable;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static io.micronaut.kubernetes.util.KubernetesMountedVolumesUtils.configMapAsPropertySource;
+
+
+/**
+ * A {@link ConfigurationClient} implementation that provides {@link PropertySource}s read from Kubernetes ConfigMap's.
+ *
+ * @author Stephane Paulus
+ * @since 1.0.0
+ */
+@Singleton
+@Requires(property = ConfigurationClient.ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
+@BootstrapContextCompatible
+public class KubernetesMountedVolumeConfigurationClient implements ConfigurationClient {
+
+    public static final String KUBERNETES_SECRET_NAME_SUFFIX = " (Kubernetes Secret)";
+    public static final String KUBERNETES_CONFIG_MAP_NAME_SUFFIX = " (Kubernetes ConfigMap)";
+
+    private static final Logger LOG = LoggerFactory.getLogger(KubernetesMountedVolumeConfigurationClient.class);
+
+    private static Map<String, PropertySource> propertySources = new ConcurrentHashMap<>();
+
+    private final KubernetesConfiguration configuration;
+
+    /**
+     * @param configuration The configuration properties
+     */
+    public KubernetesMountedVolumeConfigurationClient(KubernetesConfiguration configuration) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Initializing {}", getClass().getName());
+        }
+        this.configuration = configuration;
+    }
+
+    /**
+     * Adds the given {@link PropertySource} to the cache.
+     *
+     * @param propertySource The property source to add
+     */
+    public static void addPropertySourceToCache(PropertySource propertySource) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Adding property source {} to cache", propertySource.getName());
+        }
+        propertySources.put(propertySource.getName(), propertySource);
+    }
+
+    /**
+     * Removes the given {@link PropertySource} name from the cache.
+     *
+     * @param name The property source name
+     */
+    static void removePropertySourceFromCache(String name) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Removing property source {} to cache", name);
+        }
+        propertySources.remove(name);
+    }
+
+    /**
+     * @return the property source cache.
+     */
+    static Map<String, PropertySource> getPropertySourceCache() {
+        return propertySources;
+    }
+
+    /**
+     * Retrieves all of the {@link PropertySource} registrations for the given environment.
+     *
+     * @param environment The environment
+     * @return A {@link Publisher} that emits zero or many {@link PropertySource} instances discovered for the given environment
+     */
+    @Override
+    public Publisher<PropertySource> getPropertySources(Environment environment) {
+        if (!propertySources.isEmpty()) {
+            LOG.trace("Found cached PropertySources. Returning them");
+            return Flowable.fromIterable(propertySources.values());
+        } else {
+            LOG.trace("PropertySource cache is empty");
+            return getPropertySourcesFromConfigMaps().mergeWith(getPropertySourcesFromSecrets());
+        }
+    }
+
+    /**
+     * A description that describes this object.
+     *
+     * @return The description
+     */
+    @Override
+    public String getDescription() {
+        return KubernetesClient.SERVICE_ID;
+    }
+
+    private Flowable<PropertySource> getPropertySourcesFromConfigMaps() {
+
+        Flowable<PropertySource> propertySourceFlowable = Flowable.empty();
+        if (configuration.getConfigMaps().isEnabled()) {
+            Collection<String> mountedVolumePaths = configuration.getConfigMaps().getPaths();
+            if (!mountedVolumePaths.isEmpty()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Reading configmap from the following mounted volumes: {}", mountedVolumePaths);
+                }
+
+                List<PropertySource> propertySources = new ArrayList<>();
+                mountedVolumePaths.stream()
+                        .map(Paths::get)
+                        .forEach(path -> {
+                            LOG.trace("Processing path: {}", path);
+                            try (DirectoryStream<Path> stream = Files.newDirectoryStream(path)) {
+                                for (Path file : stream) {
+                                    if (!Files.isDirectory(file)) {
+                                        String key = file.getFileName().toString();
+                                        String value = new String(Files.readAllBytes(file));
+                                        if (LOG.isTraceEnabled()) {
+                                            LOG.trace("Processing key: {}", key);
+                                        }
+                                        final HashMap<String, String> objectObjectHashMap = new HashMap();
+                                        objectObjectHashMap.put(key, value);
+                                        final PropertySource propertySource = configMapAsPropertySource(key, objectObjectHashMap);
+                                        addPropertySourceToCache(propertySource);
+                                        propertySources.add(propertySource);
+                                    }
+                                }
+                            } catch (IOException e) {
+                                LOG.warn("Exception occurred when reading configmap from path: {}", path);
+                                LOG.warn(e.getMessage(), e);
+                            }
+                        });
+
+                propertySourceFlowable = propertySourceFlowable.mergeWith(Flowable.fromIterable(propertySources));
+            }
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Kubernetes configmap access is disabled");
+            }
+        }
+        return propertySourceFlowable;
+    }
+
+    private Flowable<PropertySource> getPropertySourcesFromSecrets() {
+        Flowable<PropertySource> propertySourceFlowable = Flowable.empty();
+        if (configuration.getSecrets().isEnabled()) {
+            Collection<String> mountedVolumePaths = configuration.getSecrets().getPaths();
+            if (!mountedVolumePaths.isEmpty()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Reading Secrets from the following mounted volumes: {}", mountedVolumePaths);
+                }
+
+                List<PropertySource> propertySources = new ArrayList<>();
+                mountedVolumePaths.stream()
+                        .map(Paths::get)
+                        .forEach(path -> {
+                            LOG.trace("Processing path: {}", path);
+                            try (DirectoryStream<Path> stream = Files.newDirectoryStream(path)) {
+                                Map<String, Object> propertySourceContents = new HashMap<>();
+                                for (Path file : stream) {
+                                    if (!Files.isDirectory(file)) {
+                                        String key = file.getFileName().toString();
+                                        String value = new String(Files.readAllBytes(file));
+                                        if (LOG.isTraceEnabled()) {
+                                            LOG.trace("Processing key: {}", key);
+                                        }
+                                        propertySourceContents.put(key, value);
+                                    }
+                                }
+                                String propertySourceName = path.toString() + KUBERNETES_SECRET_NAME_SUFFIX;
+                                int priority = EnvironmentPropertySource.POSITION + 150;
+                                PropertySource propertySource = PropertySource.of(propertySourceName, propertySourceContents, priority);
+                                addPropertySourceToCache(propertySource);
+                                propertySources.add(propertySource);
+                            } catch (IOException e) {
+                                LOG.warn("Exception occurred when reading secrets from path: {}", path);
+                                LOG.warn(e.getMessage(), e);
+                            }
+                        });
+
+                propertySourceFlowable = propertySourceFlowable.mergeWith(Flowable.fromIterable(propertySources));
+            }
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Kubernetes secrets access is disabled");
+            }
+        }
+        return propertySourceFlowable;
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/MountedVolumeChangedEvent.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/MountedVolumeChangedEvent.java
@@ -5,13 +5,15 @@ import io.micronaut.context.event.ApplicationEvent;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.scheduling.io.watch.event.WatchEventType;
 
-
 import javax.annotation.concurrent.Immutable;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 
 /**
+ * <p>An {@link MountedVolumeChangedEvent} for handling mounted volume changes.</p>
  *
+ * @author Stephane Paulus
+ * @since 1.0.0
  */
 @Immutable
 public class MountedVolumeChangedEvent extends ApplicationEvent {
@@ -22,9 +24,9 @@ public class MountedVolumeChangedEvent extends ApplicationEvent {
     /**
      * Constructs a new file changed event.
      *
-     * @param path      The path
-     * @param isConfigMap      The isConfigMap
-     * @param eventType The event type
+     * @param path        The path
+     * @param isConfigMap The isConfigMap
+     * @param eventType   The event type
      */
     public MountedVolumeChangedEvent(@NonNull Path path, @NonNull boolean isConfigMap, @NonNull WatchEventType eventType) {
         super(path);
@@ -39,9 +41,9 @@ public class MountedVolumeChangedEvent extends ApplicationEvent {
     /**
      * Constructs a new file changed event.
      *
-     * @param path      The path
-     * @param isConfigMap      The isConfigMap
-     * @param eventType The event type
+     * @param path        The path
+     * @param isConfigMap The isConfigMap
+     * @param eventType   The event type
      */
     public MountedVolumeChangedEvent(@NonNull Path path, @NonNull boolean isConfigMap, @NonNull WatchEvent.Kind eventType) {
         this(path, isConfigMap, WatchEventType.of(eventType));

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/MountedVolumeChangedEvent.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/MountedVolumeChangedEvent.java
@@ -1,0 +1,85 @@
+package io.micronaut.kubernetes.configuration;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.context.event.ApplicationEvent;
+import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.scheduling.io.watch.event.WatchEventType;
+
+
+import javax.annotation.concurrent.Immutable;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+
+/**
+ *
+ */
+@Immutable
+public class MountedVolumeChangedEvent extends ApplicationEvent {
+    private final Path path;
+    private final boolean isConfigMap;
+    private final WatchEventType eventType;
+
+    /**
+     * Constructs a new file changed event.
+     *
+     * @param path      The path
+     * @param isConfigMap      The isConfigMap
+     * @param eventType The event type
+     */
+    public MountedVolumeChangedEvent(@NonNull Path path, @NonNull boolean isConfigMap, @NonNull WatchEventType eventType) {
+        super(path);
+        ArgumentUtils.requireNonNull("path", path);
+        ArgumentUtils.requireNonNull("isConfigMap", isConfigMap);
+        ArgumentUtils.requireNonNull("eventType", eventType);
+        this.path = path;
+        this.isConfigMap = isConfigMap;
+        this.eventType = eventType;
+    }
+
+    /**
+     * Constructs a new file changed event.
+     *
+     * @param path      The path
+     * @param isConfigMap      The isConfigMap
+     * @param eventType The event type
+     */
+    public MountedVolumeChangedEvent(@NonNull Path path, @NonNull boolean isConfigMap, @NonNull WatchEvent.Kind eventType) {
+        this(path, isConfigMap, WatchEventType.of(eventType));
+    }
+
+    @Override
+    public @NonNull
+    Path getSource() {
+        return (Path) super.getSource();
+    }
+
+    /**
+     * The path to the file / directory that changed.
+     *
+     * @return The path
+     */
+    public @NonNull
+    Path getPath() {
+        return path;
+    }
+
+    /**
+     * If the file that is changed is a configmap.
+     *
+     * @return The path
+     */
+    public boolean isConfigMap() {
+        return isConfigMap;
+    }
+
+    /**
+     * The watch event type.
+     *
+     * @return The event type
+     */
+    public @NonNull
+    WatchEventType getEventType() {
+        return eventType;
+    }
+}
+

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/MountedVolumeWatchListener.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/MountedVolumeWatchListener.java
@@ -3,54 +3,68 @@ package io.micronaut.kubernetes.configuration;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.EnvironmentPropertySource;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.kubernetes.client.v1.KubernetesConfiguration;
+import io.micronaut.runtime.context.scope.Refreshable;
 import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
-import io.micronaut.scheduling.io.watch.event.WatchEventType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.WatchEvent;
+import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
-import static io.micronaut.kubernetes.util.KubernetesUtils.configMapAsPropertySource;
+import static io.micronaut.kubernetes.util.KubernetesMountedVolumesUtils.configMapAsPropertySource;
+
 
 /**
+ * Implementation of {@link MountedVolumeChangedEvent}.
  *
+ * @author Stephane Paulus
+ * @since 1.0.0
  */
-@Requires(beans = ApplicationContext.class)
+@Requires(beans = KubernetesConfiguration.class)
 @Requires(beans = Environment.class)
-@Requires(property = KubernetesConfiguration.PREFIX + ".enabled", notEquals = "false")
 @Singleton
 public class MountedVolumeWatchListener implements ApplicationEventListener<MountedVolumeChangedEvent> {
 
     private static final Logger LOG = LoggerFactory.getLogger(MountedVolumeWatchListener.class);
     private final ApplicationContext context;
-    private final KubernetesConfiguration kubernetesConfiguration;
+    private final KubernetesConfiguration configuration;
     private Environment environment;
 
     /**
      * Default constructor.
      *
-     * @param environment             The environment
-     * @param context                 The ApplicationContext
-     * @param kubernetesConfiguration The kubernetesConfiguration
+     * @param environment The environment
+     * @param context The applicationContext
+     * @param configuration The kubernetesConfiguration
      */
-    public MountedVolumeWatchListener(Environment environment, ApplicationContext context, KubernetesConfiguration kubernetesConfiguration) {
+    public MountedVolumeWatchListener(Environment environment, ApplicationContext context, KubernetesConfiguration configuration) {
         this.environment = environment;
         this.context = context;
-        this.kubernetesConfiguration = kubernetesConfiguration;
+        this.configuration = configuration;
     }
 
     @Override
     public void onApplicationEvent(MountedVolumeChangedEvent event) {
-        processConfigMapEvent(event);
+        if (event.isConfigMap()) {
+            processConfigMapDeleted();
+            processConfigMapEvent();
+        } else {
+            processSecretDeleted();
+            processSecretEvent();
+        }
     }
 
     @Override
@@ -58,85 +72,96 @@ public class MountedVolumeWatchListener implements ApplicationEventListener<Moun
         return true;
     }
 
-    private void processConfigMapEvent(MountedVolumeChangedEvent event) {
-        if (event.isConfigMap()) {
-            Path filePath = event.getPath();
-            try {
-                if (!Files.isDirectory(filePath)) {
-                    String key = filePath.getFileName().toString();
-                    String value = new String(Files.readAllBytes(filePath));
-                    final Map<String, String> objectObjectHashMap = new HashMap();
-                    objectObjectHashMap.put(key, value);
-                    WatchEventType kind = event.getEventType();
-                    switch (event.getEventType()) {
-                        case CREATE:
-                            processConfigMapAdded(key, objectObjectHashMap);
-                        case MODIFY:
-                            processConfigMapModified(key, objectObjectHashMap);
-                        case DELETE:
-                            processConfigMapDeleted(key, objectObjectHashMap);
-                        default:
-                            processConfigMapErrored(kind);
-                    }
-
+    private void processConfigMapEvent() {
+        if (configuration.getConfigMaps().isEnabled()) {
+            Collection<String> mountedVolumePaths = configuration.getConfigMaps().getPaths();
+            if (!mountedVolumePaths.isEmpty()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Reading configmap from the following mounted volumes: {}", mountedVolumePaths);
                 }
-            } catch (IOException e) {
-                LOG.warn("Exception occurred when reading file from path: {}", filePath);
-                LOG.warn(e.getMessage(), e);
+                mountedVolumePaths.stream()
+                        .map(Paths::get)
+                        .forEach(path -> {
+                            LOG.trace("Processing path: {}", path);
+                            try (DirectoryStream<Path> stream = Files.newDirectoryStream(path)) {
+                                for (Path file : stream) {
+                                    if (!Files.isDirectory(file)) {
+                                        String key = file.getFileName().toString();
+                                        String value = new String(Files.readAllBytes(file));
+                                        if (LOG.isTraceEnabled()) {
+                                            LOG.trace("Processing key: {}", key);
+                                        }
+                                        final HashMap<String, String> objectObjectHashMap = new HashMap();
+                                        objectObjectHashMap.put(key, value);
+                                        final PropertySource propertySource = configMapAsPropertySource(key, objectObjectHashMap);
+                                        this.environment.addPropertySource(propertySource);
+                                        KubernetesMountedVolumeConfigurationClient.addPropertySourceToCache(propertySource);
+                                        this.environment = environment.refresh();
+                                        context.publishEvent(new RefreshEvent());
+                                    }
+                                }
+                            } catch (IOException e) {
+                                LOG.warn("Exception occurred when reading configmap from path: {}", path);
+                                LOG.warn(e.getMessage(), e);
+                            }
+                        });
             }
         }
     }
 
-    private void processConfigMapAdded(String key, Map<String, String> data) {
-        PropertySource propertySource = null;
-        if (data != null) {
-            propertySource = configMapAsPropertySource(key, data);
+    private void processSecretEvent() {
+        if (configuration.getSecrets().isEnabled()) {
+            Collection<String> mountedVolumePaths = configuration.getSecrets().getPaths();
+            if (!mountedVolumePaths.isEmpty()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Reading Secrets from the following mounted volumes: {}", mountedVolumePaths);
+                }
+
+                mountedVolumePaths.stream()
+                        .map(Paths::get)
+                        .forEach(path -> {
+                            LOG.trace("Processing path: {}", path);
+                            try (DirectoryStream<Path> stream = Files.newDirectoryStream(path)) {
+                                Map<String, Object> propertySourceContents = new HashMap<>();
+                                for (Path file : stream) {
+                                    if (!Files.isDirectory(file)) {
+                                        String key = file.getFileName().toString();
+                                        String value = new String(Files.readAllBytes(file));
+                                        if (LOG.isTraceEnabled()) {
+                                            LOG.trace("Processing key: {}", key);
+                                        }
+                                        propertySourceContents.put(key, value);
+                                    }
+                                }
+                                String propertySourceName = path.toString() + KubernetesMountedVolumeConfigurationClient.KUBERNETES_SECRET_NAME_SUFFIX;
+                                int priority = EnvironmentPropertySource.POSITION + 150;
+                                PropertySource propertySource = PropertySource.of(propertySourceName, propertySourceContents, priority);
+                                this.environment.addPropertySource(propertySource);
+                                KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
+                                this.environment = environment.refresh();
+                                context.publishEvent(new RefreshEvent());
+                            } catch (IOException e) {
+                                LOG.warn("Exception occurred when reading secrets from path: {}", path);
+                                LOG.warn(e.getMessage(), e);
+                            }
+                        });
+            }
         }
-        this.environment.addPropertySource(propertySource);
-        KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
+    }
+
+    private void processConfigMapDeleted() {
+        final List<PropertySource> configMapPropertySources = this.environment.getPropertySources().stream().filter(propertySource -> propertySource.getName()
+                .contains(KubernetesConfigurationClient.KUBERNETES_CONFIG_MAP_NAME_SUFFIX)).collect(Collectors.toList());
+        configMapPropertySources.forEach(propertySource -> this.environment.removePropertySource(propertySource));
+        configMapPropertySources.forEach(propertySource -> KubernetesMountedVolumeConfigurationClient.removePropertySourceFromCache(propertySource.getName()));
         this.environment = environment.refresh();
-        context.publishEvent(new RefreshEvent());
     }
 
-    private void processConfigMapModified(String key, Map<String, String> data) {
-        PropertySource propertySource = null;
-        if (data != null) {
-            propertySource = configMapAsPropertySource(key, data);
-        }
-
-        this.environment.removePropertySource(propertySource);
-        this.environment.addPropertySource(propertySource);
-        KubernetesConfigurationClient.removePropertySourceFromCache(propertySource.getName());
-        KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
+    private void processSecretDeleted() {
+        final List<PropertySource> configMapPropertySources = this.environment.getPropertySources().stream().filter(propertySource -> propertySource.getName()
+                .contains(KubernetesMountedVolumeConfigurationClient.KUBERNETES_SECRET_NAME_SUFFIX)).collect(Collectors.toList());
+        configMapPropertySources.forEach(propertySource -> this.environment.removePropertySource(propertySource));
+        configMapPropertySources.forEach(propertySource -> KubernetesMountedVolumeConfigurationClient.removePropertySourceFromCache(propertySource.getName()));
         this.environment = environment.refresh();
-        context.publishEvent(new RefreshEvent());
-    }
-
-    private void processConfigMapDeleted(String key, Map<String, String> data) {
-        PropertySource propertySource = null;
-        if (data != null) {
-            propertySource = configMapAsPropertySource(key, data);
-        }
-        this.environment.removePropertySource(propertySource);
-        KubernetesConfigurationClient.removePropertySourceFromCache(propertySource.getName());
-        this.environment = environment.refresh();
-        context.publishEvent(new RefreshEvent());
-    }
-
-    private void processConfigMapErrored(WatchEventType event) {
-        LOG.error("Kubernetes API returned an error for a ConfigMap watch event: {}", event.toString());
-    }
-
-    private void processSecretModified(PropertySource propertySource) {
-        this.environment.removePropertySource(propertySource);
-        this.environment.addPropertySource(propertySource);
-        KubernetesConfigurationClient.removePropertySourceFromCache(propertySource.getName());
-        KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
-        this.environment = environment.refresh();
-        context.publishEvent(new RefreshEvent());
-    }
-
-    private void processSecretErrored(WatchEvent<?> event) {
-        LOG.error("Kubernetes API returned an error for a ConfigMap watch event: {}", event.toString());
     }
 }

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/MountedVolumeWatchListener.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/MountedVolumeWatchListener.java
@@ -1,0 +1,142 @@
+package io.micronaut.kubernetes.configuration;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.kubernetes.client.v1.KubernetesConfiguration;
+import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
+import io.micronaut.scheduling.io.watch.event.WatchEventType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.micronaut.kubernetes.util.KubernetesUtils.configMapAsPropertySource;
+
+/**
+ *
+ */
+@Requires(beans = ApplicationContext.class)
+@Requires(beans = Environment.class)
+@Requires(property = KubernetesConfiguration.PREFIX + ".enabled", notEquals = "false")
+@Singleton
+public class MountedVolumeWatchListener implements ApplicationEventListener<MountedVolumeChangedEvent> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MountedVolumeWatchListener.class);
+    private final ApplicationContext context;
+    private final KubernetesConfiguration kubernetesConfiguration;
+    private Environment environment;
+
+    /**
+     * Default constructor.
+     *
+     * @param environment             The environment
+     * @param context                 The ApplicationContext
+     * @param kubernetesConfiguration The kubernetesConfiguration
+     */
+    public MountedVolumeWatchListener(Environment environment, ApplicationContext context, KubernetesConfiguration kubernetesConfiguration) {
+        this.environment = environment;
+        this.context = context;
+        this.kubernetesConfiguration = kubernetesConfiguration;
+    }
+
+    @Override
+    public void onApplicationEvent(MountedVolumeChangedEvent event) {
+        processConfigMapEvent(event);
+    }
+
+    @Override
+    public boolean supports(MountedVolumeChangedEvent event) {
+        return true;
+    }
+
+    private void processConfigMapEvent(MountedVolumeChangedEvent event) {
+        if (event.isConfigMap()) {
+            Path filePath = event.getPath();
+            try {
+                if (!Files.isDirectory(filePath)) {
+                    String key = filePath.getFileName().toString();
+                    String value = new String(Files.readAllBytes(filePath));
+                    final Map<String, String> objectObjectHashMap = new HashMap();
+                    objectObjectHashMap.put(key, value);
+                    WatchEventType kind = event.getEventType();
+                    switch (event.getEventType()) {
+                        case CREATE:
+                            processConfigMapAdded(key, objectObjectHashMap);
+                        case MODIFY:
+                            processConfigMapModified(key, objectObjectHashMap);
+                        case DELETE:
+                            processConfigMapDeleted(key, objectObjectHashMap);
+                        default:
+                            processConfigMapErrored(kind);
+                    }
+
+                }
+            } catch (IOException e) {
+                LOG.warn("Exception occurred when reading file from path: {}", filePath);
+                LOG.warn(e.getMessage(), e);
+            }
+        }
+    }
+
+    private void processConfigMapAdded(String key, Map<String, String> data) {
+        PropertySource propertySource = null;
+        if (data != null) {
+            propertySource = configMapAsPropertySource(key, data);
+        }
+        this.environment.addPropertySource(propertySource);
+        KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
+        this.environment = environment.refresh();
+        context.publishEvent(new RefreshEvent());
+    }
+
+    private void processConfigMapModified(String key, Map<String, String> data) {
+        PropertySource propertySource = null;
+        if (data != null) {
+            propertySource = configMapAsPropertySource(key, data);
+        }
+
+        this.environment.removePropertySource(propertySource);
+        this.environment.addPropertySource(propertySource);
+        KubernetesConfigurationClient.removePropertySourceFromCache(propertySource.getName());
+        KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
+        this.environment = environment.refresh();
+        context.publishEvent(new RefreshEvent());
+    }
+
+    private void processConfigMapDeleted(String key, Map<String, String> data) {
+        PropertySource propertySource = null;
+        if (data != null) {
+            propertySource = configMapAsPropertySource(key, data);
+        }
+        this.environment.removePropertySource(propertySource);
+        KubernetesConfigurationClient.removePropertySourceFromCache(propertySource.getName());
+        this.environment = environment.refresh();
+        context.publishEvent(new RefreshEvent());
+    }
+
+    private void processConfigMapErrored(WatchEventType event) {
+        LOG.error("Kubernetes API returned an error for a ConfigMap watch event: {}", event.toString());
+    }
+
+    private void processSecretModified(PropertySource propertySource) {
+        this.environment.removePropertySource(propertySource);
+        this.environment.addPropertySource(propertySource);
+        KubernetesConfigurationClient.removePropertySourceFromCache(propertySource.getName());
+        KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
+        this.environment = environment.refresh();
+        context.publishEvent(new RefreshEvent());
+    }
+
+    private void processSecretErrored(WatchEvent<?> event) {
+        LOG.error("Kubernetes API returned an error for a ConfigMap watch event: {}", event.toString());
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/MountedVolumeWatchThread.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/MountedVolumeWatchThread.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kubernetes.configuration;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.context.LifeCycle;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.kubernetes.client.v1.KubernetesConfiguration;
+import io.micronaut.scheduling.io.watch.FileWatchCondition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Singleton;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+/**
+ * Watches for ConfigMap changes.
+ */
+@Requires(condition = FileWatchCondition.class)
+@Requires(beans = WatchService.class)
+@Requires(property = KubernetesConfiguration.PREFIX + "." + KubernetesConfiguration.PREFIX + ".watch", notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
+@Singleton
+public class MountedVolumeWatchThread implements LifeCycle<MountedVolumeWatchThread> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MountedVolumeWatchThread.class);
+    private final KubernetesConfiguration configuration;
+    private final AtomicBoolean active = new AtomicBoolean(true);
+    private final ApplicationEventPublisher eventPublisher;
+    private final WatchService watchService;
+    private final Collection<WatchKey> secretWatchKeys = new ConcurrentLinkedQueue<>();
+    private final Collection<WatchKey> configMapWatchKeys = new ConcurrentLinkedQueue<>();
+
+    /**
+     * Default constructor.
+     *
+     * @param eventPublisher The event publisher
+     * @param configuration  the configuration
+     * @param watchService   the watch service
+     */
+    protected MountedVolumeWatchThread(
+            ApplicationEventPublisher eventPublisher,
+            KubernetesConfiguration configuration,
+            WatchService watchService) {
+        this.eventPublisher = eventPublisher;
+        this.configuration = configuration;
+        this.watchService = watchService;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return active.get();
+    }
+
+    @Override
+    @PostConstruct
+    public MountedVolumeWatchThread start() {
+        try {
+            final List<Path> configMapPaths = configuration.getConfigMaps().getPaths().stream().map(Paths::get).collect(Collectors.toList());
+            if (!configMapPaths.isEmpty()) {
+                for (Path path : configMapPaths) {
+                    if (path.toFile().exists()) {
+                        addConfigMapWatchDirectory(path);
+                    }
+                }
+            }
+
+            final List<Path> secretPaths = configuration.getSecrets().getPaths().stream().map(Paths::get).collect(Collectors.toList());
+            if (!secretPaths.isEmpty()) {
+                for (Path path : secretPaths) {
+                    if (path.toFile().exists()) {
+                        addSecretWatchDirectory(path);
+                    }
+                }
+            }
+
+            if (!configMapWatchKeys.isEmpty()) {
+                new Thread(() -> {
+                    while (active.get()) {
+                        try {
+                            WatchKey watchKey = watchService.poll(Duration.ofMillis(300).toMillis(), TimeUnit.MILLISECONDS);
+                            if (watchKey != null && configMapWatchKeys.contains(watchKey)) {
+                                List<WatchEvent<?>> watchEvents = watchKey.pollEvents();
+                                for (WatchEvent<?> watchEvent : watchEvents) {
+                                    WatchEvent.Kind<?> kind = watchEvent.kind();
+                                    if (kind == StandardWatchEventKinds.OVERFLOW) {
+                                        if (LOG.isWarnEnabled()) {
+                                            LOG.warn("WatchService Overflow occurred");
+                                        }
+                                    } else {
+                                        final Object context = watchEvent.context();
+                                        if (context instanceof Path) {
+
+                                            if (LOG.isDebugEnabled()) {
+                                                LOG.debug("File at path {} changed. Firing change event: {}", context, kind);
+                                            }
+                                            eventPublisher.publishEvent(new MountedVolumeChangedEvent(
+                                                    (Path) context,
+                                                    true,
+                                                    kind
+                                            ));
+                                        }
+                                    }
+                                }
+                                watchKey.reset();
+                            }
+                        } catch (InterruptedException | ClosedWatchServiceException e) {
+                            // ignore
+                        }
+                    }
+                }, "micronaut-configmapwatch-thread").start();
+            }
+
+            if (!secretWatchKeys.isEmpty()) {
+                new Thread(() -> {
+                    while (active.get()) {
+                        try {
+                            WatchKey watchKey = watchService.poll(Duration.ofMillis(300).toMillis(), TimeUnit.MILLISECONDS);
+                            if (watchKey != null && secretWatchKeys.contains(watchKey)) {
+                                List<WatchEvent<?>> watchEvents = watchKey.pollEvents();
+                                for (WatchEvent<?> watchEvent : watchEvents) {
+                                    WatchEvent.Kind<?> kind = watchEvent.kind();
+                                    if (kind == StandardWatchEventKinds.OVERFLOW) {
+                                        if (LOG.isWarnEnabled()) {
+                                            LOG.warn("WatchService Overflow occurred");
+                                        }
+                                    } else {
+                                        final Object context = watchEvent.context();
+                                        if (context instanceof Path) {
+
+                                            if (LOG.isDebugEnabled()) {
+                                                LOG.debug("File at path {} changed. Firing change event: {}", context, kind);
+                                            }
+                                            eventPublisher.publishEvent(new MountedVolumeChangedEvent(
+                                                    (Path) context,
+                                                    false,
+                                                    kind
+                                            ));
+                                        }
+                                    }
+                                }
+                                watchKey.reset();
+                            }
+                        } catch (InterruptedException | ClosedWatchServiceException e) {
+                            // ignore
+                        }
+                    }
+                }, "micronaut-configmapwatch-thread").start();
+            }
+        } catch (IOException e) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error("Error starting file watch service: " + e.getMessage(), e);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public MountedVolumeWatchThread stop() {
+        active.set(false);
+        closeWatchService();
+        return this;
+    }
+
+    @Override
+    @PreDestroy
+    public void close() {
+        stop();
+    }
+
+    /**
+     * @return The watch service used.
+     */
+    public @NonNull
+    WatchService getWatchService() {
+        return watchService;
+    }
+
+    /**
+     * Closes the watch service.
+     */
+    protected void closeWatchService() {
+        try {
+            getWatchService().close();
+        } catch (IOException e) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error("Error stopping file watch service: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Registers a patch to watch.
+     *
+     * @param dir The directory to watch
+     * @return The watch key
+     * @throws IOException if an error occurs.
+     */
+    protected @NonNull
+    WatchKey registerPath(@NonNull Path dir) throws IOException {
+        return dir.register(watchService,
+                StandardWatchEventKinds.ENTRY_CREATE,
+                StandardWatchEventKinds.ENTRY_DELETE,
+                StandardWatchEventKinds.ENTRY_MODIFY
+        );
+    }
+
+    private boolean isValidDirectoryToMonitor(File file) {
+        return file.isDirectory() && !file.isHidden() && !file.getName().startsWith(".");
+    }
+
+    private Path addConfigMapWatchDirectory(Path p) throws IOException {
+        return Files.walkFileTree(p, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                    throws IOException {
+
+                if (!isValidDirectoryToMonitor(dir.toFile())) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                WatchKey watchKey = registerPath(dir);
+                configMapWatchKeys.add(watchKey);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private Path addSecretWatchDirectory(Path p) throws IOException {
+        return Files.walkFileTree(p, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                    throws IOException {
+
+                if (!isValidDirectoryToMonitor(dir.toFile())) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                WatchKey watchKey = registerPath(dir);
+                secretWatchKeys.add(watchKey);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesMountedVolumesUtils.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesMountedVolumesUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kubernetes.util;
+
+import io.micronaut.context.env.EnvironmentPropertySource;
+import io.micronaut.context.env.PropertiesPropertySourceLoader;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.context.env.PropertySourceReader;
+import io.micronaut.context.env.yaml.YamlPropertySourceLoader;
+import io.micronaut.jackson.env.JsonPropertySourceLoader;
+import io.micronaut.kubernetes.configuration.KubernetesMountedVolumeConfigurationClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Utility class with methods to help with ConfigMaps and Secrets read from mounted volumes
+ *
+ * @author Stephane Paulus
+ * @since 1.0.0
+ */
+public class KubernetesMountedVolumesUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KubernetesMountedVolumesUtils.class);
+    private static final List<PropertySourceReader> PROPERTY_SOURCE_READERS = Arrays.asList(
+            new YamlPropertySourceLoader(),
+            new JsonPropertySourceLoader(),
+            new PropertiesPropertySourceLoader());
+
+    /**
+     * Converts a {@link String} and a {@link Map<String,String>}  into a {@link PropertySource}.
+     *
+     * @param key the key
+     * @param data the configmaps data
+     * @return A PropertySource
+     */
+    public static PropertySource configMapAsPropertySource(String key, Map<String, String> data) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Processing PropertySources for ConfigMap: {}", key);
+        }
+        String name = key + KubernetesMountedVolumeConfigurationClient.KUBERNETES_CONFIG_MAP_NAME_SUFFIX;
+
+        if (data == null || data.isEmpty()) {
+            return PropertySource.of(Collections.emptyMap());
+        }
+
+        Map.Entry<String, String> entry = data.entrySet().iterator().next();
+        if (data.size() > 1 || !getExtension(entry.getKey()).isPresent()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Considering this ConfigMap as containing multiple literal key/values");
+            }
+            Map<String, Object> propertySourceData = new HashMap<>(data);
+            return PropertySource.of(name, propertySourceData);
+        } else {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Considering this ConfigMap as containing values from a single file");
+            }
+            String extension = getExtension(entry.getKey()).get();
+            int priority = EnvironmentPropertySource.POSITION + 150;
+            PropertySource propertySource = PROPERTY_SOURCE_READERS.stream()
+                    .filter(reader -> reader.getExtensions().contains(extension))
+                    .map(reader -> reader.read(entry.getKey(), entry.getValue().getBytes()))
+                    .map(map -> PropertySource.of(entry.getKey() + KubernetesMountedVolumeConfigurationClient.KUBERNETES_CONFIG_MAP_NAME_SUFFIX, map, priority))
+                    .findFirst()
+                    .orElse(PropertySource.of(Collections.emptyMap()));
+
+            KubernetesMountedVolumeConfigurationClient.addPropertySourceToCache(propertySource);
+
+            return propertySource;
+        }
+    }
+
+    private static Optional<String> getExtension(String filename) {
+        return Optional.of(filename)
+                .filter(f -> f.contains("."))
+                .map(f -> f.substring(filename.lastIndexOf(".") + 1));
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesUtils.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesUtils.java
@@ -96,42 +96,6 @@ public class KubernetesUtils {
         }
     }
 
-    public static PropertySource configMapAsPropertySource(String key, Map<String, String> data) {
-        if (LOG.isTraceEnabled()) {
-            LOG.trace("Processing PropertySources for ConfigMap: {}", key);
-        }
-        String name = key + KubernetesConfigurationClient.KUBERNETES_CONFIG_MAP_NAME_SUFFIX;
-
-        if (data == null || data.isEmpty()) {
-            return PropertySource.of(Collections.emptyMap());
-        }
-
-        Map.Entry<String, String> entry = data.entrySet().iterator().next();
-        if (data.size() > 1 || !getExtension(entry.getKey()).isPresent()) {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Considering this ConfigMap as containing multiple literal key/values");
-            }
-            Map<String, Object> propertySourceData = new HashMap<>(data);
-            return PropertySource.of(name, propertySourceData);
-        } else {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Considering this ConfigMap as containing values from a single file");
-            }
-            String extension = getExtension(entry.getKey()).get();
-            int priority = EnvironmentPropertySource.POSITION + 150;
-            PropertySource propertySource = PROPERTY_SOURCE_READERS.stream()
-                    .filter(reader -> reader.getExtensions().contains(extension))
-                    .map(reader -> reader.read(entry.getKey(), entry.getValue().getBytes()))
-                    .map(map -> PropertySource.of(entry.getKey() + KubernetesConfigurationClient.KUBERNETES_CONFIG_MAP_NAME_SUFFIX, map, priority))
-                    .findFirst()
-                    .orElse(PropertySource.of(Collections.emptyMap()));
-
-            KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
-
-            return propertySource;
-        }
-    }
-
     /**
      * Determines the value of a Kubernetes labelSelector filter based on the passed labels.
      *

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesUtils.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesUtils.java
@@ -96,6 +96,42 @@ public class KubernetesUtils {
         }
     }
 
+    public static PropertySource configMapAsPropertySource(String key, Map<String, String> data) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Processing PropertySources for ConfigMap: {}", key);
+        }
+        String name = key + KubernetesConfigurationClient.KUBERNETES_CONFIG_MAP_NAME_SUFFIX;
+
+        if (data == null || data.isEmpty()) {
+            return PropertySource.of(Collections.emptyMap());
+        }
+
+        Map.Entry<String, String> entry = data.entrySet().iterator().next();
+        if (data.size() > 1 || !getExtension(entry.getKey()).isPresent()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Considering this ConfigMap as containing multiple literal key/values");
+            }
+            Map<String, Object> propertySourceData = new HashMap<>(data);
+            return PropertySource.of(name, propertySourceData);
+        } else {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Considering this ConfigMap as containing values from a single file");
+            }
+            String extension = getExtension(entry.getKey()).get();
+            int priority = EnvironmentPropertySource.POSITION + 150;
+            PropertySource propertySource = PROPERTY_SOURCE_READERS.stream()
+                    .filter(reader -> reader.getExtensions().contains(extension))
+                    .map(reader -> reader.read(entry.getKey(), entry.getValue().getBytes()))
+                    .map(map -> PropertySource.of(entry.getKey() + KubernetesConfigurationClient.KUBERNETES_CONFIG_MAP_NAME_SUFFIX, map, priority))
+                    .findFirst()
+                    .orElse(PropertySource.of(Collections.emptyMap()));
+
+            KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
+
+            return propertySource;
+        }
+    }
+
     /**
      * Determines the value of a Kubernetes labelSelector filter based on the passed labels.
      *


### PR DESCRIPTION
POC for #280 

I tested the code locally (no automated test yet)  and it does work, however the code is a bit strange. The code has almost nothing to do with Kubernetes anymore. The only thing that relates to kubernetes is the way Kubernetes changes data in mounted volumes. 
The game.properties file is actually a symbolic link, so you cannot have watch events on this. Every time the files are changed, Kubernetes creates a directory like: `..2021_03_18_17_30_18.531648931` and creates some temp folders and deletes the old ones. 

These are the events fired every time a change happens in chronological order:
```
File at path ..2021_03_18_17_30_18.531648931 changed. Firing change event: ENTRY_CREATE
File at path ..2021_03_18_17_30_18.531648931 changed. Firing change event: ENTRY_MODIFY
File at path test.properties changed. Firing change event: ENTRY_CREATE
File at path ..data_tmp changed. Firing change event: ENTRY_CREATE
File at path ..data_tmp changed. Firing change event: ENTRY_DELETE
File at path ..data changed. Firing change event: ENTRY_CREATE
File at path ..2021_03_18_17_17_29.703573822 changed. Firing change event: ENTRY_DELETE
```
In the code I just listen to the 1 MODIFY event, remove all propertysources and add them all back again after. 

Maybe this code should be in a different repo as another bootstrap/client-config/hot-reload file repo. Instead of using Consul,  Kubernetes,... you just use files to drive you configuration and have the possibility to change them on the fly. 

Looking forward to ideas.