### PR TITLE
Send a RefreshEvent when the environment is refreshed because of a ConfigMap change

### DIFF
--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
@@ -55,7 +55,7 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
 
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesConfigMapWatcher.class);
 
-    private Environment environment;
+    private final Environment environment;
     private final KubernetesClient client;
     private final KubernetesConfiguration configuration;
     private final ExecutorService executorService;
@@ -101,7 +101,7 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
     }
 
     private long computeLastResourceVersion() {
-        long lastResourceVersion = this.environment
+        long lastResourceVersion = environment
                 .getPropertySources()
                 .stream()
                 .filter(propertySource -> propertySource.getName().endsWith(KUBERNETES_CONFIG_MAP_NAME_SUFFIX))
@@ -144,9 +144,9 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
             propertySource = KubernetesUtils.configMapAsPropertySource(configMap);
         }
         if (passesIncludesExcludesLabelsFilters(configMap)) {
-            this.environment.addPropertySource(propertySource);
+            environment.addPropertySource(propertySource);
             KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
-            this.environment = environment.refresh();
+            environment.refresh();
         }
     }
 
@@ -156,11 +156,11 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
             propertySource = KubernetesUtils.configMapAsPropertySource(configMap);
         }
         if (passesIncludesExcludesLabelsFilters(configMap)) {
-            this.environment.removePropertySource(propertySource);
-            this.environment.addPropertySource(propertySource);
+            environment.removePropertySource(propertySource);
+            environment.addPropertySource(propertySource);
             KubernetesConfigurationClient.removePropertySourceFromCache(propertySource.getName());
             KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
-            this.environment = environment.refresh();
+            environment.refresh();
         }
     }
 
@@ -170,9 +170,9 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
             propertySource = KubernetesUtils.configMapAsPropertySource(configMap);
         }
         if (passesIncludesExcludesLabelsFilters(configMap)) {
-            this.environment.removePropertySource(propertySource);
+            environment.removePropertySource(propertySource);
             KubernetesConfigurationClient.removePropertySourceFromCache(propertySource.getName());
-            this.environment = environment.refresh();
+            environment.refresh();
         }
     }
 

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
@@ -144,7 +144,6 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
             propertySource = KubernetesUtils.configMapAsPropertySource(configMap);
         }
         if (passesIncludesExcludesLabelsFilters(configMap)) {
-            environment.addPropertySource(propertySource);
             KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
             environment.refresh();
         }
@@ -156,8 +155,6 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
             propertySource = KubernetesUtils.configMapAsPropertySource(configMap);
         }
         if (passesIncludesExcludesLabelsFilters(configMap)) {
-            environment.removePropertySource(propertySource);
-            environment.addPropertySource(propertySource);
             KubernetesConfigurationClient.removePropertySourceFromCache(propertySource.getName());
             KubernetesConfigurationClient.addPropertySourceToCache(propertySource);
             environment.refresh();
@@ -170,7 +167,6 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
             propertySource = KubernetesUtils.configMapAsPropertySource(configMap);
         }
         if (passesIncludesExcludesLabelsFilters(configMap)) {
-            environment.removePropertySource(propertySource);
             KubernetesConfigurationClient.removePropertySourceFromCache(propertySource.getName());
             environment.refresh();
         }

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigurationClient.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigurationClient.java
@@ -128,7 +128,7 @@ public class KubernetesConfigurationClient implements ConfigurationClient {
      */
     static void removePropertySourceFromCache(String name) {
         if (LOG.isTraceEnabled()) {
-            LOG.trace("Removing property source {} to cache", name);
+            LOG.trace("Removing property source {} from cache", name);
         }
         propertySources.remove(name);
     }


### PR DESCRIPTION
While trying to make use of `micronaut-kubernetes` to react to changes in ConfigMaps, I read the following sentence in documentation:

```
changes [...] will be propagated to the Environment and refresh it.
```

Knowing about the `@Refreshable`, I took this to mean that a `RefreshEvent` would be published when a ConfigMap change happens.   
Currently, that's not the case so there is no way to react to the changes in the environment.

This PR makes `KubernetesConfigMapWatcher` send a `RefreshEvent` every time it changes the environment. 