### PR TITLE
Restart the watch on `410 Gone`

### DIFF
--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/Status.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/Status.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kubernetes.client.v1;
+
+import io.micronaut.core.annotation.Introspected;
+
+/**
+ * @see <a href="https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#response-status-kind">Response Status Kind</a>
+ *
+ * @author Régis Desgroppes
+ * @since 2.3.4
+ */
+@Introspected
+public class Status extends KubernetesObject {
+
+    private String status;
+    private String message;
+    private String reason;
+    private int code;
+
+    /**
+     * @return The Status
+     */
+    public String getStatus() {
+        return status;
+    }
+
+    /**
+     * @param status The Status
+     */
+    public void setStatus(final String status) {
+        this.status = status;
+    }
+
+    /**
+     * @return The Message
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * @param message The Message
+     */
+    public void setMessage(final String message) {
+        this.message = message;
+    }
+
+    /**
+     * @return The Reason
+     */
+    public String getReason() {
+        return reason;
+    }
+
+    /**
+     * @param reason The Reason
+     */
+    public void setReason(final String reason) {
+        this.reason = reason;
+    }
+
+    /**
+     * @return The Code
+     */
+    public int getCode() {
+        return code;
+    }
+
+    /**
+     * @param code The Code
+     */
+    public void setCode(final int code) {
+        this.code = code;
+    }
+
+    @Override
+    public String toString() {
+        return "Status{" +
+                "status=" + status +
+                ", message=" + message +
+                ", reason=" + reason +
+                ", code=" + code +
+                '}';
+    }
+}

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/configmaps/ConfigMapWatchEvent.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/client/v1/configmaps/ConfigMapWatchEvent.java
@@ -15,7 +15,11 @@
  */
 package io.micronaut.kubernetes.client.v1.configmaps;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.kubernetes.client.v1.KubernetesObject;
+import io.micronaut.kubernetes.client.v1.Status;
 
 /**
  * Represents a ConfigMap watch event returned from the Kubernetes API.
@@ -27,7 +31,13 @@ import io.micronaut.core.annotation.Introspected;
 public class ConfigMapWatchEvent {
 
     private EventType type;
-    private ConfigMap object;
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", defaultImpl = ConfigMap.class)
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = ConfigMap.class, name = "ConfigMap"),
+            @JsonSubTypes.Type(value = Status.class, name = "Status"),
+    })
+    private KubernetesObject object;
 
     /**
      * The default constructor.
@@ -57,16 +67,16 @@ public class ConfigMapWatchEvent {
     }
 
     /**
-     * @return the {@link ConfigMap} object
+     * @return the {@link KubernetesObject} object
      */
-    public ConfigMap getObject() {
+    public KubernetesObject getObject() {
         return object;
     }
 
     /**
-     * @param object the {@link ConfigMap} object
+     * @param object the {@link KubernetesObject} object
      */
-    public void setObject(ConfigMap object) {
+    public void setObject(KubernetesObject object) {
         this.object = object;
     }
 

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
@@ -125,15 +125,15 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
     private void processEvent(ConfigMapWatchEvent event) {
         switch (event.getType()) {
             case ADDED:
-                processConfigMapAdded(event.getObject());
+                processConfigMapAdded((ConfigMap) event.getObject());
                 break;
 
             case MODIFIED:
-                processConfigMapModified(event.getObject());
+                processConfigMapModified((ConfigMap) event.getObject());
                 break;
 
             case DELETED:
-                processConfigMapDeleted(event.getObject());
+                processConfigMapDeleted((ConfigMap) event.getObject());
                 break;
 
             case ERROR:

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
@@ -26,6 +26,7 @@ import io.micronaut.kubernetes.client.v1.KubernetesClient;
 import io.micronaut.kubernetes.client.v1.KubernetesConfiguration;
 import io.micronaut.kubernetes.client.v1.configmaps.ConfigMap;
 import io.micronaut.kubernetes.client.v1.configmaps.ConfigMapWatchEvent;
+import io.micronaut.kubernetes.client.v1.configmaps.ConfigMapWatchEvent.EventType;
 import io.micronaut.kubernetes.util.KubernetesUtils;
 import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
 import io.reactivex.Flowable;
@@ -82,9 +83,13 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
         this.eventPublisher = eventPublisher;
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public void onApplicationEvent(ServiceReadyEvent event) {
+        watch();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private void watch() {
         long lastResourceVersion = computeLastResourceVersion();
         Map<String, String> labels = configuration.getConfigMaps().getLabels();
         Flowable<String> singleLabelSelector = computePodLabelSelector(client, configuration.getConfigMaps().getPodLabels(), configuration.getNamespace(), labels);
@@ -101,7 +106,7 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
                 })
                 .doOnError(throwable -> LOG.error("Error while watching ConfigMap events", throwable))
                 .subscribeOn(Schedulers.from(this.executorService))
-                .onErrorReturnItem(new ConfigMapWatchEvent(ConfigMapWatchEvent.EventType.ERROR))
+                .onErrorReturnItem(new ConfigMapWatchEvent(EventType.ERROR))
                 .subscribe(this::processEvent);
     }
 
@@ -178,7 +183,7 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
     }
 
     /**
-     * Send a {@link RefreshEvent} when a {@link ConfigMap} change affects the {@link Environment}
+     * Send a {@link RefreshEvent} when a {@link ConfigMap} change affects the {@link Environment}.
      *
      * @see io.micronaut.management.endpoint.refresh.RefreshEndpoint#refresh(Boolean)
      */
@@ -192,8 +197,16 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
         }
     }
 
+    /**
+     * Process {@link EventType#ERROR} events, unconditionally restarting the watch.
+     *
+     * @see <a href="https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes">Efficient detection of changes</a>
+     */
     private void processConfigMapErrored(ConfigMapWatchEvent event) {
         LOG.error("Kubernetes API returned an error for a ConfigMap watch event: {}", event.toString());
+        KubernetesConfigurationClient.getPropertySourceCache().clear();
+        refreshEnvironment();
+        watch();
     }
 
     private boolean passesIncludesExcludesLabelsFilters(ConfigMap configMap) {


### PR DESCRIPTION
As per [Efficient detection of changes](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes):
> When the requested watch operations fail because the historical
> version of that resource is not available, clients must handle the
> case by recognizing the status code `410 Gone`, clearing their local
> cache, performing a list operation, and starting the watch from the
> `resourceVersion` returned by that new list operation.