### PR TITLE
Log status on watch error

### DIFF
--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
@@ -235,7 +235,7 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
      * @see <a href="https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes">Efficient detection of changes</a>
      */
     private void processConfigMapErrored(Watch.Response<V1ConfigMap> event) {
-        LOG.error("Kubernetes API returned an error for a ConfigMap watch event: {}", event.toString());
+        LOG.error("Kubernetes API returned an error for a ConfigMap watch event: {}", event.status);
         KubernetesConfigurationClient.getPropertySourceCache().clear();
         refreshEnvironment();
         watch();


### PR DESCRIPTION
Current log message doesn't help understanding what went wrong:
> Kubernetes API returned an error for a ConfigMap watch event: io.kubernetes.client.util.Watch$Response@13ebdaa5

The present change will dump the `status` field instead, see:
[V1Status](https://github.com/kubernetes-client/java/blob/master/kubernetes/docs/V1Status.md)