### PR TITLE
Remove nested `watch`

### DIFF
--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
@@ -96,7 +96,7 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
         executorService.execute(this::watch);
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @SuppressWarnings("InfiniteLoopStatement")
     private void watch() {
         while (true) {
             String lastResourceVersion = computeLastResourceVersion();
@@ -230,15 +230,15 @@ public class KubernetesConfigMapWatcher implements ApplicationEventListener<Serv
     }
 
     /**
-     * Process {@code ERROR} events, unconditionally restarting the watch.
+     * Process {@code ERROR} events.
      *
+     * @implNote the watch is automatically restarted from within the {@link #watch} loop
      * @see <a href="https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes">Efficient detection of changes</a>
      */
     private void processConfigMapErrored(Watch.Response<V1ConfigMap> event) {
         LOG.error("Kubernetes API returned an error for a ConfigMap watch event: {}", event.status);
         KubernetesConfigurationClient.getPropertySourceCache().clear();
         refreshEnvironment();
-        watch();
     }
 
     private boolean passesIncludesExcludesLabelsFilters(V1ConfigMap configMap) {


### PR DESCRIPTION
Now the watch is (re)started from within a `while` loop, there's no need
for restarting it in the error handler specifically. Also, keeping it
there may potentially lead to stack overflows: `watch` ->
`processConfigMapErrored` -> `watch` -> `processConfigMapErrored` -> ...