### PR TITLE
Fix issues #392 and #391  (#393)

### DIFF
--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
@@ -25,6 +25,7 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.discovery.config.ConfigurationClient;
 import io.micronaut.discovery.event.ServiceReadyEvent;
 import io.micronaut.kubernetes.KubernetesConfiguration;
 import io.micronaut.kubernetes.client.informer.Informer;
@@ -52,6 +53,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Context
 @Requires(env = Environment.KUBERNETES)
 @Requires(beans = CoreV1ApiReactorClient.class)
+@Requires(property = ConfigurationClient.ENABLED, value = "true", defaultValue = "false")
 @Requires(condition = KubernetesConfigMapWatcherCondition.class)
 @Informer(apiType = V1ConfigMap.class, apiListType = V1ConfigMapList.class, resourcePlural = "configmaps", apiGroup = "", labelSelectorSupplier = ConfigMapLabelSupplier.class)
 public class KubernetesConfigMapWatcher implements ResourceEventHandler<V1ConfigMap> {

--- a/kubernetes-discovery-client/src/test/groovy/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcherSpec.groovy
+++ b/kubernetes-discovery-client/src/test/groovy/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcherSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.kubernetes.configuration
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.env.Environment
+import io.micronaut.discovery.config.ConfigurationClient
 import io.micronaut.kubernetes.test.TestUtils
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Requires
@@ -21,9 +22,17 @@ class KubernetesConfigMapWatcherSpec extends Specification {
         applicationContext.containsBean(KubernetesConfigMapWatcher)
     }
 
-    void "KubernetesConfigMapWatcher can be disabled"() {
+    void "KubernetesConfigMapWatcher is explicitly disabled"() {
         given:
         ApplicationContext applicationContext = ApplicationContext.run(["kubernetes.client.config-maps.watch": "false"], Environment.KUBERNETES)
+
+        expect:
+        !applicationContext.containsBean(KubernetesConfigMapWatcher)
+    }
+
+    void "KubernetesConfigMapWatcher is disabled when config-client is disabled"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run(["micronaut.config-client.enabled": "false"], Environment.KUBERNETES)
 
         expect:
         !applicationContext.containsBean(KubernetesConfigMapWatcher)

--- a/kubernetes-informer/src/test/groovy/io/micronaut/kubernetes/client/informer/DuplicitConfigMapInformerSpec.groovy
+++ b/kubernetes-informer/src/test/groovy/io/micronaut/kubernetes/client/informer/DuplicitConfigMapInformerSpec.groovy
@@ -1,0 +1,76 @@
+package io.micronaut.kubernetes.client.informer
+
+import io.fabric8.kubernetes.api.model.ConfigMap
+import io.kubernetes.client.openapi.models.V1ConfigMap
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.env.Environment
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.kubernetes.test.KubernetesSpecification
+import io.micronaut.kubernetes.test.TestUtils
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Requires
+import spock.lang.Shared
+import spock.util.concurrent.PollingConditions
+
+
+@MicronautTest(environments = [Environment.KUBERNETES])
+@Requires({ TestUtils.kubernetesApiAvailable() })
+@Property(name = "kubernetes.client.namespace", value = "micronaut-informer")
+@Property(name = "spec.reuseNamespace", value = "false")
+@Property(name = "spec.name", value = "ConfigMapInformerSpec")
+class DuplicitConfigMapInformerSpec extends KubernetesSpecification {
+
+    @Shared
+    @Inject
+    ApplicationContext applicationContext
+
+    @Override
+    def setupFixture(String namespace) {
+        createNamespaceSafe(namespace)
+    }
+
+    def "resource handlers with same type and namespace are notified"() {
+        given:
+        DuplicitConfigMapInformer informer1 = applicationContext.getBean(DuplicitConfigMapInformer.class)
+        ConfigMapInformer informer2 = applicationContext.getBean(ConfigMapInformer.class)
+
+        expect:
+        informer1.updated.isEmpty() && informer1.deleted.isEmpty()
+        informer2.updated.isEmpty() && informer2.deleted.isEmpty()
+
+        when:
+        operations.createConfigMap("map1", namespace, ["foo": "bar"])
+
+        then:
+        new PollingConditions().within(5) {
+            assert informer1.added.stream().filter(cm -> cm.metadata.name == "map1")
+                    .findFirst().isPresent()
+            assert informer2.added.stream().filter(cm -> cm.metadata.name == "map1")
+                    .findFirst().isPresent()
+        }
+
+        when:
+        ConfigMap cm = operations.getConfigMap("map1", namespace)
+        cm.data.put("ping", "pong")
+        operations.modifyConfigMap("map1", namespace, cm.data)
+
+        then:
+        new PollingConditions().within(5) {
+            assert informer1.updated.size() == 1
+            assert informer2.updated.size() == 1
+        }
+
+
+        when:
+        operations.deleteConfigMap("map1", namespace)
+
+        then:
+        new PollingConditions().within(5) {
+            assert informer1.deleted.size() == 1
+            assert informer2.deleted.size() == 1
+        }
+    }
+}

--- a/kubernetes-informer/src/test/java/io/micronaut/kubernetes/client/informer/DuplicitConfigMapInformer.java
+++ b/kubernetes-informer/src/test/java/io/micronaut/kubernetes/client/informer/DuplicitConfigMapInformer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kubernetes.client.informer;
+
+import io.kubernetes.client.informer.ResourceEventHandler;
+import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1ConfigMapList;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+import org.apache.commons.compress.utils.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+@Requires(property = "spec.name", value = "ConfigMapInformerSpec")
+@Singleton
+@Informer(apiType = V1ConfigMap.class, apiListType = V1ConfigMapList.class)
+public class DuplicitConfigMapInformer implements ResourceEventHandler<V1ConfigMap> {
+
+    public static final Logger LOG = LoggerFactory.getLogger(DuplicitConfigMapInformer.class);
+
+    private final List<V1ConfigMap> added = Lists.newArrayList();
+    private final List<V1ConfigMap> updated = Lists.newArrayList();
+    private final List<V1ConfigMap> deleted = Lists.newArrayList();
+
+    public List<V1ConfigMap> getAdded() {
+        return added;
+    }
+
+    public List<V1ConfigMap> getUpdated() {
+        return updated;
+    }
+
+    public List<V1ConfigMap> getDeleted() {
+        return deleted;
+    }
+
+    @Override
+    public void onAdd(V1ConfigMap obj) {
+        LOG.info("ADDED CONFIG MAP: {}", obj);
+        added.add(obj);
+    }
+
+    @Override
+    public void onUpdate(V1ConfigMap oldObj, V1ConfigMap newObj) {
+        LOG.info("UPDATED CONFIG MAP: {}", newObj);
+        updated.add(newObj);
+    }
+
+    @Override
+    public void onDelete(V1ConfigMap obj, boolean deletedFinalStateUnknown) {
+        LOG.info("DELETED CONFIG MAP: {}", obj);
+        deleted.add(obj);
+    }
+}


### PR DESCRIPTION
* fix: reuse existing informer

* fix: don't create KubernetesConfigMapWatcher when config-client is disabled