### PR TITLE
Inject Discovery and ApiClient lazily

### DIFF
--- a/kubernetes-client/src/main/java/io/micronaut/kubernetes/client/DiscoveryCache.java
+++ b/kubernetes-client/src/main/java/io/micronaut/kubernetes/client/DiscoveryCache.java
@@ -72,7 +72,7 @@ public class DiscoveryCache {
      * @param discovery A provider for the discovery object to cache
      * @param apiDiscoveryCacheConfiguration the cache configuration
      *
-     * @deprecated Use a provider instead {@link DiscoveryCache#DiscoveryCache(Provider, ApiClientConfiguration.ApiDiscoveryCacheConfiguration)}
+     * @since 3.4.0
      */
     @Inject
     public DiscoveryCache(Provider<Discovery> discovery,

--- a/kubernetes-informer/src/main/java/io/micronaut/kubernetes/client/informer/DefaultSharedIndexInformerFactory.java
+++ b/kubernetes-informer/src/main/java/io/micronaut/kubernetes/client/informer/DefaultSharedIndexInformerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.kubernetes.client.ModelMapper;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +66,20 @@ public class DefaultSharedIndexInformerFactory extends SharedInformerFactory imp
     private static final ModelMapper MAPPER = new ModelMapper();
 
     private final InformerConfiguration informerConfiguration;
-    private final ApiClient apiClient;
+    private final Provider<ApiClient> apiClient;
+
+    /**
+     * Creates {@link DefaultSharedIndexInformer}.
+     *
+     * @param informerConfiguration informer configuration
+     * @param apiClient             api client
+     *
+     * @deprecated Moved to use the lazy constructor, see {@link DefaultSharedIndexInformerFactory#DefaultSharedIndexInformerFactory(InformerConfiguration, Provider)}
+     */
+    @Deprecated
+    public DefaultSharedIndexInformerFactory(InformerConfiguration informerConfiguration, ApiClient apiClient) {
+        this(informerConfiguration, () -> apiClient);
+    }
 
     /**
      * Creates {@link DefaultSharedIndexInformer}.
@@ -72,7 +87,8 @@ public class DefaultSharedIndexInformerFactory extends SharedInformerFactory imp
      * @param informerConfiguration informer configuration
      * @param apiClient             api client
      */
-    public DefaultSharedIndexInformerFactory(InformerConfiguration informerConfiguration, ApiClient apiClient) {
+    @Inject
+    public DefaultSharedIndexInformerFactory(InformerConfiguration informerConfiguration, Provider<ApiClient> apiClient) {
         this.apiClient = apiClient;
         this.informerConfiguration = informerConfiguration;
     }
@@ -128,7 +144,7 @@ public class DefaultSharedIndexInformerFactory extends SharedInformerFactory imp
                 apiGroup,
                 version,
                 resourcePlural,
-                new CustomObjectsApi(apiClient));
+                new CustomObjectsApi(apiClient.get()));
 
         final SharedIndexInformer<ApiType> informer = sharedIndexInformerFor(
                 listerWatcherFor(kubernetesApi, labelSelector, ns),

--- a/kubernetes-informer/src/main/java/io/micronaut/kubernetes/client/informer/DefaultSharedIndexInformerFactory.java
+++ b/kubernetes-informer/src/main/java/io/micronaut/kubernetes/client/informer/DefaultSharedIndexInformerFactory.java
@@ -86,6 +86,8 @@ public class DefaultSharedIndexInformerFactory extends SharedInformerFactory imp
      *
      * @param informerConfiguration informer configuration
      * @param apiClient             api client
+     *
+     * @since 3.4.0
      */
     @Inject
     public DefaultSharedIndexInformerFactory(InformerConfiguration informerConfiguration, Provider<ApiClient> apiClient) {

--- a/kubernetes-informer/src/test/groovy/io/micronaut/kubernetes/client/informer/ApiClientCreationListenerSpec.groovy
+++ b/kubernetes-informer/src/test/groovy/io/micronaut/kubernetes/client/informer/ApiClientCreationListenerSpec.groovy
@@ -1,0 +1,56 @@
+package io.micronaut.kubernetes.client.informer
+
+import io.kubernetes.client.openapi.ApiClient
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.context.event.BeanCreatedEvent
+import io.micronaut.context.event.BeanCreatedEventListener
+import io.micronaut.kubernetes.test.KubernetesSpecification
+import io.micronaut.kubernetes.test.TestUtils
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Shared
+
+@MicronautTest(environments = [Environment.KUBERNETES])
+@spock.lang.Requires({ TestUtils.kubernetesApiAvailable() })
+@Property(name = "kubernetes.client.namespace", value = "micronaut-api-client-creation")
+@Property(name = "spec.reuseNamespace", value = "false")
+@Property(name = "spec.name", value = "ApiClientCreationListenerSpec")
+class ApiClientCreationListenerSpec  extends KubernetesSpecification {
+
+    @Shared
+    @Inject
+    ApplicationContext applicationContext
+
+    static boolean eventFired = false
+
+    @Override
+    def setupFixture(String namespace) {
+        createNamespaceSafe(namespace)
+    }
+
+    def "should fire"() {
+        expect:
+        !eventFired
+
+        when:
+        applicationContext.getBean(ApiClient)
+
+        then:
+        eventFired
+    }
+
+    @Requires(property = "spec.name", value = "ApiClientCreationListenerSpec")
+    @Singleton
+    static class K8sClientEventListener implements BeanCreatedEventListener<ApiClient> {
+
+        @Override
+        public ApiClient onCreated(BeanCreatedEvent<ApiClient> event) {
+            eventFired = true
+            return event.getBean();
+        }
+    }
+}


### PR DESCRIPTION
Beans created inside a `BeanCreatedEventListener` do not themselves
trigger other `BeanCreatedEventListener`s.

This change uses a provider to supply these lazily where required
so we can listen for ApiClient creation again

Closes #435

I've tagged this a 3.4.0 as it is an alteration to the public API