### PR TITLE
Switch property source readers from hardcoded version to service loader

### DIFF
--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/KubernetesConfigMapWatcher.java
@@ -56,7 +56,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Requires(property = ConfigurationClient.ENABLED, value = "true", defaultValue = "false")
 @Requires(condition = KubernetesConfigMapWatcherCondition.class)
 @Informer(apiType = V1ConfigMap.class, apiListType = V1ConfigMapList.class, resourcePlural = "configmaps", apiGroup = "", labelSelectorSupplier = ConfigMapLabelSupplier.class)
-public class KubernetesConfigMapWatcher implements ResourceEventHandler<V1ConfigMap> {
+public final class KubernetesConfigMapWatcher implements ResourceEventHandler<V1ConfigMap> {
 
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesConfigMapWatcher.class);
 

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesUtils.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesUtils.java
@@ -20,14 +20,13 @@ import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Secret;
-import io.micronaut.context.env.AbstractPropertySourceLoader;
 import io.micronaut.context.env.EnvironmentPropertySource;
 import io.micronaut.context.env.PropertySource;
+import io.micronaut.context.env.PropertySourceLoader;
 import io.micronaut.context.env.PropertySourceReader;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.kubernetes.client.reactor.CoreV1ApiReactorClient;
 import io.micronaut.kubernetes.configuration.KubernetesConfigurationClient;
-import org.apache.commons.collections4.IteratorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -58,7 +57,7 @@ public class KubernetesUtils {
 
     public static final String ENV_KUBERNETES_SERVICE_HOST = "KUBERNETES_SERVICE_HOST";
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesUtils.class);
-    private static final List<PropertySourceReader> PROPERTY_SOURCE_READERS = StreamSupport.stream(ServiceLoader.load(PropertySourceReader.class).spliterator(), false).collect(Collectors.toList());
+    private static final List<PropertySourceReader> PROPERTY_SOURCE_READERS = StreamSupport.stream(ServiceLoader.load(PropertySourceLoader.class).spliterator(), false).collect(Collectors.toList());
 
     /**
      * Converts a {@link V1ConfigMap} into a {@link PropertySource}.

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesUtils.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesUtils.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static io.micronaut.kubernetes.configuration.KubernetesConfigurationClient.KUBERNETES_CONFIG_MAP_NAME_SUFFIX;
 import static io.micronaut.kubernetes.health.KubernetesHealthIndicator.HOSTNAME_ENV_VARIABLE;
@@ -57,7 +58,7 @@ public class KubernetesUtils {
 
     public static final String ENV_KUBERNETES_SERVICE_HOST = "KUBERNETES_SERVICE_HOST";
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesUtils.class);
-    private static final List<PropertySourceReader> PROPERTY_SOURCE_READERS = IteratorUtils.toList(ServiceLoader.load(AbstractPropertySourceLoader.class).iterator());
+    private static final List<PropertySourceReader> PROPERTY_SOURCE_READERS = StreamSupport.stream(ServiceLoader.load(PropertySourceReader.class).spliterator(), false).collect(Collectors.toList());
 
     /**
      * Converts a {@link V1ConfigMap} into a {@link PropertySource}.

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesUtils.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/util/KubernetesUtils.java
@@ -20,21 +20,19 @@ import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Secret;
+import io.micronaut.context.env.AbstractPropertySourceLoader;
 import io.micronaut.context.env.EnvironmentPropertySource;
-import io.micronaut.context.env.PropertiesPropertySourceLoader;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.env.PropertySourceReader;
-import io.micronaut.context.env.yaml.YamlPropertySourceLoader;
 import io.micronaut.context.exceptions.ConfigurationException;
-import io.micronaut.jackson.env.JsonPropertySourceLoader;
 import io.micronaut.kubernetes.client.reactor.CoreV1ApiReactorClient;
 import io.micronaut.kubernetes.configuration.KubernetesConfigurationClient;
+import org.apache.commons.collections4.IteratorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -58,10 +57,7 @@ public class KubernetesUtils {
 
     public static final String ENV_KUBERNETES_SERVICE_HOST = "KUBERNETES_SERVICE_HOST";
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesUtils.class);
-    private static final List<PropertySourceReader> PROPERTY_SOURCE_READERS = Arrays.asList(
-            new YamlPropertySourceLoader(),
-            new JsonPropertySourceLoader(),
-            new PropertiesPropertySourceLoader());
+    private static final List<PropertySourceReader> PROPERTY_SOURCE_READERS = IteratorUtils.toList(ServiceLoader.load(AbstractPropertySourceLoader.class).iterator());
 
     /**
      * Converts a {@link V1ConfigMap} into a {@link PropertySource}.


### PR DESCRIPTION
This PR uses `ServiceLoader` to load `PropertySourceLoader`.