### PR TITLE
Adds package-info inside Kubernetes informer

### DIFF
--- a/kubernetes-informer/src/main/java/io/micronaut/kubernetes/client/informer/package-info.java
+++ b/kubernetes-informer/src/main/java/io/micronaut/kubernetes/client/informer/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains classes specific to Kubernetes informer
+ *
+ * @author Nemanja Mikic
+ * @since 3.4.1
+ */
+
+@Configuration
+@Requires(env = Environment.KUBERNETES)
+package io.micronaut.kubernetes.client.informer;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;

--- a/kubernetes-informer/src/main/java/io/micronaut/kubernetes/client/informer/package-info.java
+++ b/kubernetes-informer/src/main/java/io/micronaut/kubernetes/client/informer/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * Contains classes specific to Kubernetes informer
+ * Contains classes specific to Kubernetes informer.
  *
  * @author Nemanja Mikic
  * @since 3.4.1


### PR DESCRIPTION
This PR adds package-info inside Kubernetes informer and requires environment to be set as Kubernetes.

This is needed because of this change:
https://github.com/micronaut-projects/micronaut-kubernetes/blob/269865161abc754c44ce29e831b7af580b867a96/kubernetes-client/src/main/java/io/micronaut/kubernetes/client/DefaultNamespaceResolver.java#L43

Informer depends on `DefaultNamespaceResolver` and discovery client depends on informer. In users application when test are ran it will give:

```
Message: No bean of type [io.micronaut.kubernetes.client.NamespaceResolver] exists. Make sure the bean is not disabled by bean requirements (enable trace logging for 'io.micronaut.context.condition' to check) and if the bean is enabled then ensure the class is declared a bean and annotation processing is enabled (for Java and Kotlin the 'micronaut-inject-java' dependency should be configured as an annotation processor).
Path Taken: new ResourceEventHandlerBeanListener(SharedIndexInformerFactory sharedIndexInformerFactory,InformerApiGroupResolver apiGroupResolver,InformerResourcePluralResolver resourcePluralResolver,InformerNamespaceResolver namespaceResolver,InformerLabelSelectorResolver labelSelectorResolver) --> new ResourceEventHandlerBeanListener(SharedIndexInformerFactory sharedIndexInformerFactory,InformerApiGroupResolver apiGroupResolver,InformerResourcePluralResolver resourcePluralResolver,[InformerNamespaceResolver namespaceResolver],InformerLabelSelectorResolver labelSelectorResolver) --> new DefaultInformerNamespaceResolver([NamespaceResolver namespaceResolver],BeanContext beanContext,DiscoveryCache discoveryCache)
io.micronaut.context.exceptions.DependencyInjectionException: Failed to inject value for parameter [namespaceResolve
```

With this change the users test are executed as expeceted.