### PR TITLE
Fix for documentation building

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,3 @@ plugins {
     id "io.micronaut.build.internal.docs"
     id "io.micronaut.build.internal.quality-reporting"
 }
-
-repositories {
-    mavenCentral()
-}
-
-configurations.all {
-    resolutionStrategy {
-        preferProjectModules()
-    }
-}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.kubernetes-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.kubernetes-base.gradle
@@ -1,3 +1,9 @@
 repositories {
     mavenCentral()
 }
+
+configurations.all {
+    resolutionStrategy {
+        preferProjectModules()
+    }
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.kubernetes-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.kubernetes-module.gradle
@@ -2,3 +2,10 @@ plugins {
     id "io.micronaut.build.internal.module"
     id "io.micronaut.build.internal.kubernetes-base"
 }
+
+// Fix for JavaDoc not finding generated classes
+configurations {
+    internalJavadocClasspathElements {
+        outgoing.artifact(tasks.named("jar"))
+    }
+}


### PR DESCRIPTION
JavaDoc couldn't find the generated sources, so I borrowed a fix from core to make javadoc require the annotation processor and a jar to have been built prior to documentation.

https://github.com/micronaut-projects/micronaut-core/blob/83df97cb53ebec57626b4e4120675b6793b98f68/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-library.gradle#L24-L30

Also moved things out of the root build script, as I don't think that's where they typically go.

Closes #568