### PR TITLE
Implement support for custom Api Versions in informers (#639)

### DIFF
--- a/kubernetes-client/src/main/java/io/micronaut/kubernetes/client/ModelMapper.java
+++ b/kubernetes-client/src/main/java/io/micronaut/kubernetes/client/ModelMapper.java
@@ -50,7 +50,9 @@ public class ModelMapper {
     private final List<String> preBuiltApiVersions = new ArrayList<>();
 
     // This allows parsing custom (not included in kubernetes core) api versions
-    private final Pattern customVersionParser = Pattern.compile("(V[a-z1-9]+)[A-Z]+[a-zA-Z0-9]+");
+    // It is based on the kubernetes core one available at https://github.com/kubernetes/apimachinery/blob/master/pkg/util/version/version.go
+    // and is completed to be able to proceed to extraction from a java class name
+    private final Pattern customVersionParser = Pattern.compile("^\\s*(V(?:[0-9]+(?:\\.[0-9]+)*)(?:[a-z0-9]*)*)[A-Z]+[a-zA-Z0-9]*$");
 
     public ModelMapper() {
         initApiGroupMap();

--- a/kubernetes-client/src/test/groovy/io/micronaut/kubernetes/client/ModelMapperSpec.groovy
+++ b/kubernetes-client/src/test/groovy/io/micronaut/kubernetes/client/ModelMapperSpec.groovy
@@ -25,4 +25,15 @@ class ModelMapperSpec extends Specification {
             it.kind == "ClusterRole"
         }
     }
+
+    def "it resolves custom api versions"() {
+        expect:
+        with(mapper.getGroupVersionKindByClass(V3CustomResource)) {
+            it.version == "v3"
+            it.group == ""
+            it.kind == "CustomResource"
+        }
+    }
+
+    static class V3CustomResource{}
 }


### PR DESCRIPTION
This adds the support of custom api versions to the informer library as discussed in #639