### PR TITLE
Changed order of api package names in openapi-reactor module

### DIFF
--- a/examples/example-kubernetes-client-openapi-reactor-java/src/main/java/micronaut/client/PodController.java
+++ b/examples/example-kubernetes-client-openapi-reactor-java/src/main/java/micronaut/client/PodController.java
@@ -2,7 +2,7 @@ package micronaut.client;
 
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
-import io.micronaut.kubernetes.client.openapi.api.reactor.CoreV1ApiReactor;
+import io.micronaut.kubernetes.client.openapi.reactor.api.CoreV1ApiReactor;
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.NotNull;
 import reactor.core.publisher.Mono;

--- a/kubernetes-client-openapi-reactor/build.gradle
+++ b/kubernetes-client-openapi-reactor/build.gradle
@@ -18,7 +18,7 @@ micronaut {
     }
     openapi {
         client("client", tasks.named("downloadKubernetesClientOpenApiSpec", DownloadSpec).flatMap(DownloadSpec::getSpecFile)) {
-            apiPackageName = "io.micronaut.kubernetes.client.openapi.api.reactor"
+            apiPackageName = "io.micronaut.kubernetes.client.openapi.reactor.api"
             modelPackageName = "io.micronaut.kubernetes.client.openapi.model"
             apiNameSuffix = "ApiReactor"
             clientId = "kubernetes-client"

--- a/kubernetes-client-openapi-reactor/src/test/groovy/io/micronaut/kubernetes/client/openapi/reactor/ExecCommandTokenAuthSpec.groovy
+++ b/kubernetes-client-openapi-reactor/src/test/groovy/io/micronaut/kubernetes/client/openapi/reactor/ExecCommandTokenAuthSpec.groovy
@@ -5,11 +5,11 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
-import io.micronaut.kubernetes.client.openapi.api.reactor.CoreV1ApiReactor
 import io.micronaut.kubernetes.client.openapi.credential.model.ExecCredential
 import io.micronaut.kubernetes.client.openapi.credential.model.ExecCredentialStatus
 import io.micronaut.kubernetes.client.openapi.model.V1Pod
 import io.micronaut.kubernetes.client.openapi.model.V1PodList
+import io.micronaut.kubernetes.client.openapi.reactor.api.CoreV1ApiReactor
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.AutoCleanup
 import spock.lang.Shared

--- a/kubernetes-client-openapi-reactor/src/test/groovy/io/micronaut/kubernetes/client/openapi/reactor/KubeConfigTokenAuthSpec.groovy
+++ b/kubernetes-client-openapi-reactor/src/test/groovy/io/micronaut/kubernetes/client/openapi/reactor/KubeConfigTokenAuthSpec.groovy
@@ -5,9 +5,9 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
-import io.micronaut.kubernetes.client.openapi.api.reactor.CoreV1ApiReactor
 import io.micronaut.kubernetes.client.openapi.model.V1Pod
 import io.micronaut.kubernetes.client.openapi.model.V1PodList
+import io.micronaut.kubernetes.client.openapi.reactor.api.CoreV1ApiReactor
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.AutoCleanup
 import spock.lang.Shared

--- a/kubernetes-client-openapi-reactor/src/test/groovy/io/micronaut/kubernetes/client/openapi/reactor/KubernetesBasicAuthSpec.groovy
+++ b/kubernetes-client-openapi-reactor/src/test/groovy/io/micronaut/kubernetes/client/openapi/reactor/KubernetesBasicAuthSpec.groovy
@@ -5,9 +5,9 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
-import io.micronaut.kubernetes.client.openapi.api.reactor.CoreV1ApiReactor
 import io.micronaut.kubernetes.client.openapi.model.V1Pod
 import io.micronaut.kubernetes.client.openapi.model.V1PodList
+import io.micronaut.kubernetes.client.openapi.reactor.api.CoreV1ApiReactor
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.AutoCleanup
 import spock.lang.Shared

--- a/kubernetes-client-openapi-reactor/src/test/groovy/io/micronaut/kubernetes/client/openapi/reactor/KubernetesClientCertAuthSpec.groovy
+++ b/kubernetes-client-openapi-reactor/src/test/groovy/io/micronaut/kubernetes/client/openapi/reactor/KubernetesClientCertAuthSpec.groovy
@@ -1,7 +1,7 @@
 package io.micronaut.kubernetes.client.openapi.reactor
 
-import io.micronaut.kubernetes.client.openapi.api.reactor.CoreV1ApiReactor
 import io.micronaut.kubernetes.client.openapi.model.V1PodList
+import io.micronaut.kubernetes.client.openapi.reactor.api.CoreV1ApiReactor
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject


### PR DESCRIPTION
Changed order of package names in openapi-reactor module to match order in other openapi modules and to match the module name.
**NOTE**: This is not a breaking change since we have't released a new version of micronuat-kubernetes which contains kubernetes-client-openapi-reactor module