### PR TITLE
Delay kubeconfig loading to the filter method.

### DIFF
--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
@@ -19,6 +19,7 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ProviderUtils;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.annotation.ClientFilter;
@@ -33,6 +34,7 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 import jakarta.inject.Provider;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -45,7 +47,7 @@ import java.util.List;
 final class KubernetesHttpClientFilter {
 
     private Provider<KubeConfig> kubeConfigProvider;
-    private final Provider<Collection<KubernetesTokenLoader>> kubernetesTokenLoaders;
+    private final Provider<List<KubernetesTokenLoader>> kubernetesTokenLoaders;
 
     KubernetesHttpClientFilter(Provider<KubeConfigLoader> kubeConfigLoader,
                                ApplicationContext applicationContext) {
@@ -54,7 +56,8 @@ final class KubernetesHttpClientFilter {
         this.kubeConfigProvider = ProviderUtils.memoized(
             () -> kubeConfigLoader.get().getKubeConfig());
         this.kubernetesTokenLoaders = ProviderUtils.memoized(
-            () -> applicationContext.getBeansOfType(KubernetesTokenLoader.class));
+            () -> applicationContext.getBeansOfType(KubernetesTokenLoader.class)
+                .stream().sorted(Comparator.comparing(Ordered::getOrder)).toList());
     }
 
     @RequestFilter

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.kubernetes.client.openapi;
 
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.ProviderUtils;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.StringUtils;
@@ -28,7 +30,9 @@ import io.micronaut.kubernetes.client.openapi.config.model.AuthInfo;
 import io.micronaut.kubernetes.client.openapi.credential.KubernetesTokenLoader;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
+import jakarta.inject.Provider;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -40,24 +44,23 @@ import java.util.List;
 @Internal
 final class KubernetesHttpClientFilter {
 
-    private final KubeConfigLoader kubeConfigLoader;
-    private KubeConfig kubeConfig;
-    private boolean retrievedConfig = false;
-    private final List<KubernetesTokenLoader> kubernetesTokenLoaders;
+    private Provider<KubeConfig> kubeConfigProvider;
+    private final Provider<Collection<KubernetesTokenLoader>> kubernetesTokenLoaders;
 
-    KubernetesHttpClientFilter(KubeConfigLoader kubeConfigLoader,
-                               List<KubernetesTokenLoader> kubernetesTokenLoaders) {
-        this.kubeConfigLoader = kubeConfigLoader;
-        this.kubernetesTokenLoaders = kubernetesTokenLoaders;
+    KubernetesHttpClientFilter(Provider<KubeConfigLoader> kubeConfigLoader,
+                               ApplicationContext applicationContext) {
+        // Retrieval has to be delegated to filtering, as any of these classes might
+        // depend on a client causing a circular dependency.
+        this.kubeConfigProvider = ProviderUtils.memoized(
+            () -> kubeConfigLoader.get().getKubeConfig());
+        this.kubernetesTokenLoaders = ProviderUtils.memoized(
+            () -> applicationContext.getBeansOfType(KubernetesTokenLoader.class));
     }
 
     @RequestFilter
     @ExecuteOn(TaskExecutors.BLOCKING)
     void doFilter(MutableHttpRequest<?> request) {
-        if (!retrievedConfig) {
-            kubeConfig = kubeConfigLoader.getKubeConfig();
-            retrievedConfig = true;
-        }
+        KubeConfig kubeConfig = kubeConfigProvider.get();
         if (kubeConfig != null && kubeConfig.getUser() != null) {
             AuthInfo user = kubeConfig.getUser();
             if (user.clientCertificateData() != null && user.clientKeyData() != null) {
@@ -69,7 +72,7 @@ final class KubernetesHttpClientFilter {
             }
         }
         String token = null;
-        for (KubernetesTokenLoader kubernetesTokenLoader : kubernetesTokenLoaders) {
+        for (KubernetesTokenLoader kubernetesTokenLoader : kubernetesTokenLoaders.get()) {
             token = kubernetesTokenLoader.getToken();
             if (StringUtils.isNotEmpty(token)) {
                 break;

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
@@ -19,7 +19,6 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ProviderUtils;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.annotation.ClientFilter;
@@ -34,8 +33,6 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 import jakarta.inject.Provider;
 
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
 
 /**
  * Filter which sets the authorization request header with basic or bearer token
@@ -47,7 +44,7 @@ import java.util.List;
 final class KubernetesHttpClientFilter {
 
     private Provider<KubeConfig> kubeConfigProvider;
-    private final Provider<List<KubernetesTokenLoader>> kubernetesTokenLoaders;
+    private final Provider<Collection<KubernetesTokenLoader>> kubernetesTokenLoaders;
 
     KubernetesHttpClientFilter(Provider<KubeConfigLoader> kubeConfigLoader,
                                ApplicationContext applicationContext) {
@@ -56,8 +53,7 @@ final class KubernetesHttpClientFilter {
         this.kubeConfigProvider = ProviderUtils.memoized(
             () -> kubeConfigLoader.get().getKubeConfig());
         this.kubernetesTokenLoaders = ProviderUtils.memoized(
-            () -> applicationContext.getBeansOfType(KubernetesTokenLoader.class)
-                .stream().sorted(Comparator.comparing(Ordered::getOrder)).toList());
+            () -> applicationContext.getBeansOfType(KubernetesTokenLoader.class));
     }
 
     @RequestFilter

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
@@ -40,18 +40,24 @@ import java.util.List;
 @Internal
 final class KubernetesHttpClientFilter {
 
-    private final KubeConfig kubeConfig;
+    private final KubeConfigLoader kubeConfigLoader;
+    private KubeConfig kubeConfig;
+    private boolean retrievedConfig = false;
     private final List<KubernetesTokenLoader> kubernetesTokenLoaders;
 
     KubernetesHttpClientFilter(KubeConfigLoader kubeConfigLoader,
                                List<KubernetesTokenLoader> kubernetesTokenLoaders) {
-        kubeConfig = kubeConfigLoader.getKubeConfig();
+        this.kubeConfigLoader = kubeConfigLoader;
         this.kubernetesTokenLoaders = kubernetesTokenLoaders;
     }
 
     @RequestFilter
     @ExecuteOn(TaskExecutors.BLOCKING)
     void doFilter(MutableHttpRequest<?> request) {
+        if (!retrievedConfig) {
+            kubeConfig = kubeConfigLoader.getKubeConfig();
+            retrievedConfig = true;
+        }
         if (kubeConfig != null && kubeConfig.getUser() != null) {
             AuthInfo user = kubeConfig.getUser();
             if (user.clientCertificateData() != null && user.clientKeyData() != null) {

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
@@ -43,7 +43,7 @@ import java.util.Collection;
 @Internal
 final class KubernetesHttpClientFilter {
 
-    private Provider<KubeConfig> kubeConfigProvider;
+    private final Provider<KubeConfig> kubeConfigProvider;
     private final Provider<Collection<KubernetesTokenLoader>> kubernetesTokenLoaders;
 
     KubernetesHttpClientFilter(Provider<KubeConfigLoader> kubeConfigLoader,

--- a/kubernetes-client-openapi/build.gradle
+++ b/kubernetes-client-openapi/build.gradle
@@ -35,4 +35,5 @@ dependencies {
     api(projects.micronautKubernetesClientOpenapiCommon)
     testImplementation(libs.testcontainers.k3s)
     testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.http.client)
 }

--- a/kubernetes-client-openapi/src/test/groovy/io/micronaut/kubernetes/client/openapi/ClientConfigLoaderSpec.groovy
+++ b/kubernetes-client-openapi/src/test/groovy/io/micronaut/kubernetes/client/openapi/ClientConfigLoaderSpec.groovy
@@ -1,0 +1,136 @@
+package io.micronaut.kubernetes.client.openapi
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import io.micronaut.core.io.ResourceResolver
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Header
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.netty.DefaultHttpClient
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.kubernetes.client.openapi.api.CoreV1Api
+import io.micronaut.kubernetes.client.openapi.config.AbstractKubeConfigLoader
+import io.micronaut.kubernetes.client.openapi.config.DefaultKubeConfigLoader
+import io.micronaut.kubernetes.client.openapi.config.KubeConfig
+import io.micronaut.kubernetes.client.openapi.model.V1Pod
+import io.micronaut.kubernetes.client.openapi.model.V1PodList
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Singleton
+import org.yaml.snakeyaml.LoaderOptions
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class ClientConfigLoaderSpec extends Specification {
+
+    static final String KUBE_CONFIG = """
+apiVersion: v1
+kind: Config
+clusters:
+  - name: test-cluster
+    cluster:
+      server: %s
+users:
+  - name: test-user
+    user:
+      token: test-token
+contexts:
+  - name: test-context
+    context:
+      cluster: test-cluster
+      user: test-user
+current-context: test-context
+"""
+
+    @AutoCleanup
+    EmbeddedServer kubernetesServer = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'ClientConfigLoaderKubernetesServer',
+            'kubernetes.client.enabled': false
+    ])
+
+    @AutoCleanup
+    EmbeddedServer kubeConfigProviderServer = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'ClientConfigLoaderKubeConfigProviderServer',
+            'kubernetes.client.enabled': false,
+            'kubernetes.server.url': kubernetesServer.URL
+    ])
+
+    def 'list pods when token authentication is used'() {
+        given:
+        ApplicationContext clientContext = ApplicationContext.run([
+                'spec.name': 'ClientConfigLoaderClientContext',
+                'kube.config.provider.url': kubeConfigProviderServer.URL
+        ])
+
+        when:
+        V1PodList response = clientContext.getBean(CoreV1Api.class).listPodForAllNamespaces(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null)
+
+        then:
+        response.getItems() != null
+        response.getItems().size() == 1
+
+        cleanup:
+        clientContext.close()
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'ClientConfigLoaderClientContext')
+    @Replaces(DefaultKubeConfigLoader.class)
+    static class CustomKubeConfigLoader extends AbstractKubeConfigLoader {
+
+        HttpClient httpClient
+
+        protected CustomKubeConfigLoader(ResourceResolver resourceResolver, @Value("\${kube.config.provider.url}") kubeConfigProviderUrl) {
+            super(resourceResolver)
+            httpClient = DefaultHttpClient.builder().uri(URI.create(kubeConfigProviderUrl)).build()
+        }
+
+        @Override
+        protected KubeConfig loadKubeConfig() {
+            String uri = UriBuilder.of("/kube-config").toString()
+            String result = httpClient.toBlocking().retrieve(uri)
+            Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()))
+            Map<String, Object> configMap = yaml.load(result)
+            return new KubeConfig(configMap)
+        }
+    }
+
+    @Controller
+    @Requires(property = 'spec.name', value = 'ClientConfigLoaderKubeConfigProviderServer')
+    static class KubeConfigProviderController {
+
+        @Value("\${kubernetes.server.url}") String kubernetesServerUrl
+
+        @Get("/kube-config")
+        String getKubeConfig() {
+            return KUBE_CONFIG.formatted(kubernetesServerUrl)
+        }
+    }
+
+    @Controller
+    @Requires(property = 'spec.name', value = 'ClientConfigLoaderKubernetesServer')
+    static class KubernetesServerController {
+        @Get("/api/v1/pods")
+        V1PodList auth(@Header('Authorization') String authorization) {
+            return authorization == "Bearer test-token"
+                    ? new V1PodList(Arrays.asList(new V1Pod()))
+                    : new V1PodList(Collections.emptyList())
+
+        }
+    }
+}

--- a/kubernetes-client-openapi/src/test/groovy/io/micronaut/kubernetes/client/openapi/ClientConfigLoaderSpec.groovy
+++ b/kubernetes-client-openapi/src/test/groovy/io/micronaut/kubernetes/client/openapi/ClientConfigLoaderSpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.netty.DefaultHttpClient
 import io.micronaut.http.uri.UriBuilder
 import io.micronaut.kubernetes.client.openapi.api.CoreV1Api
@@ -18,6 +19,7 @@ import io.micronaut.kubernetes.client.openapi.config.KubeConfig
 import io.micronaut.kubernetes.client.openapi.model.V1Pod
 import io.micronaut.kubernetes.client.openapi.model.V1PodList
 import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
@@ -27,43 +29,17 @@ import spock.lang.Specification
 
 class ClientConfigLoaderSpec extends Specification {
 
-    static final String KUBE_CONFIG = """
-apiVersion: v1
-kind: Config
-clusters:
-  - name: test-cluster
-    cluster:
-      server: %s
-users:
-  - name: test-user
-    user:
-      token: test-token
-contexts:
-  - name: test-context
-    context:
-      cluster: test-cluster
-      user: test-user
-current-context: test-context
-"""
-
     @AutoCleanup
     EmbeddedServer kubernetesServer = ApplicationContext.run(EmbeddedServer, [
-            'spec.name': 'ClientConfigLoaderKubernetesServer',
+            'spec.name': 'ClientConfigLoader-Server',
             'kubernetes.client.enabled': false
-    ])
-
-    @AutoCleanup
-    EmbeddedServer kubeConfigProviderServer = ApplicationContext.run(EmbeddedServer, [
-            'spec.name': 'ClientConfigLoaderKubeConfigProviderServer',
-            'kubernetes.client.enabled': false,
-            'kubernetes.server.url': kubernetesServer.URL
     ])
 
     def 'list pods when token authentication is used'() {
         given:
         ApplicationContext clientContext = ApplicationContext.run([
-                'spec.name': 'ClientConfigLoaderClientContext',
-                'kube.config.provider.url': kubeConfigProviderServer.URL
+                'spec.name': 'ClientConfigLoader-Client',
+                'kube.config.provider.url': kubernetesServer.URL
         ])
 
         when:
@@ -89,15 +65,15 @@ current-context: test-context
     }
 
     @Singleton
-    @Requires(property = 'spec.name', value = 'ClientConfigLoaderClientContext')
+    @Requires(property = 'spec.name', value = 'ClientConfigLoader-Client')
     @Replaces(DefaultKubeConfigLoader.class)
     static class CustomKubeConfigLoader extends AbstractKubeConfigLoader {
 
         HttpClient httpClient
 
-        protected CustomKubeConfigLoader(ResourceResolver resourceResolver, @Value("\${kube.config.provider.url}") kubeConfigProviderUrl) {
+        protected CustomKubeConfigLoader(ResourceResolver resourceResolver, @Client("\${kube.config.provider.url}") HttpClient client) {
             super(resourceResolver)
-            httpClient = DefaultHttpClient.builder().uri(URI.create(kubeConfigProviderUrl)).build()
+            httpClient = client
         }
 
         @Override
@@ -111,19 +87,38 @@ current-context: test-context
     }
 
     @Controller
-    @Requires(property = 'spec.name', value = 'ClientConfigLoaderKubeConfigProviderServer')
+    @Requires(property = 'spec.name', value = 'ClientConfigLoader-Server')
     static class KubeConfigProviderController {
 
-        @Value("\${kubernetes.server.url}") String kubernetesServerUrl
+        static final String KUBE_CONFIG = """\
+apiVersion: v1
+kind: Config
+clusters:
+  - name: test-cluster
+    cluster:
+      server: %s
+users:
+  - name: test-user
+    user:
+      token: test-token
+contexts:
+  - name: test-context
+    context:
+      cluster: test-cluster
+      user: test-user
+current-context: test-context
+"""
+
+        @Inject EmbeddedServer server
 
         @Get("/kube-config")
         String getKubeConfig() {
-            return KUBE_CONFIG.formatted(kubernetesServerUrl)
+            return KUBE_CONFIG.formatted(server.getURI())
         }
     }
 
     @Controller
-    @Requires(property = 'spec.name', value = 'ClientConfigLoaderKubernetesServer')
+    @Requires(property = 'spec.name', value = 'ClientConfigLoader-Server')
     static class KubernetesServerController {
         @Get("/api/v1/pods")
         V1PodList auth(@Header('Authorization') String authorization) {

--- a/kubernetes-client-openapi/src/test/groovy/io/micronaut/kubernetes/client/openapi/ClientCredentialLoaderSpec.groovy
+++ b/kubernetes-client-openapi/src/test/groovy/io/micronaut/kubernetes/client/openapi/ClientCredentialLoaderSpec.groovy
@@ -1,0 +1,136 @@
+package io.micronaut.kubernetes.client.openapi
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.BootstrapContextCompatible
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Header
+import io.micronaut.kubernetes.client.openapi.api.CoreV1Api
+import io.micronaut.kubernetes.client.openapi.credential.KubernetesTokenLoader
+import io.micronaut.kubernetes.client.openapi.model.V1Pod
+import io.micronaut.kubernetes.client.openapi.model.V1PodList
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ClientCredentialLoaderSpec extends Specification {
+
+    static final String KUBE_CONFIG = """\
+apiVersion: v1
+kind: Config
+clusters:
+  - name: test-cluster
+    cluster:
+      server: %s
+users:
+  - name: test-user
+    user:
+      token: test-user
+contexts:
+  - name: test-context
+    context:
+      cluster: test-cluster
+      user: test-user
+current-context: test-context
+"""
+
+    @AutoCleanup
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'ClientCredentialLoaderSpec-Server',
+            'kubernetes.client.enabled': false
+    ])
+
+    @Shared
+    Path kubeConfigDir = Files.createTempDirectory("kube-temp-")
+
+    @Shared
+    Path kubeConfigFile = kubeConfigDir.resolve("config")
+
+    def cleanupSpec() {
+        if (kubeConfigFile != null) {
+            Files.deleteIfExists(kubeConfigFile)
+        }
+        if (kubeConfigDir) {
+            Files.deleteIfExists(kubeConfigDir)
+        }
+    }
+
+    def 'list pods when basic authentication is used'() {
+        given:
+        kubeConfigFile.toFile().text = KUBE_CONFIG.formatted(server.URL)
+        ApplicationContext clientContext = ApplicationContext.run([
+                'spec.name': 'ClientCredentialLoaderSpec-Client',
+                'kubernetes.client.kube-config-path': "file:" + kubeConfigFile.toString()
+        ])
+
+        when:
+        V1PodList response = clientContext.getBean(CoreV1Api.class).listPodForAllNamespaces(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null)
+
+        then:
+        response.getItems() != null
+        response.getItems().size() == 1
+
+        cleanup:
+        clientContext.close()
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'ClientCredentialLoaderSpec-Client')
+    @BootstrapContextCompatible
+    static class FirstCredentialLoader implements KubernetesTokenLoader {
+
+        @Override
+        String getToken() {
+            return "first"
+        }
+
+        @Override
+        int getOrder() {
+            return -1
+        }
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'ClientCredentialLoaderSpec-Client')
+    @BootstrapContextCompatible
+    static class SecondCredentialLoader implements KubernetesTokenLoader {
+
+        @Override
+        String getToken() {
+            return "second"
+        }
+
+        @Override
+        int getOrder() {
+            return 0
+        }
+    }
+
+    @Controller
+    @Requires(property = 'spec.name', value = 'ClientCredentialLoaderSpec-Server')
+    static class BasicAuthController {
+        @Get("/api/v1/pods")
+        V1PodList auth(@Header('Authorization') String authorization) {
+            return authorization == "Bearer first"
+                    ? new V1PodList(Arrays.asList(new V1Pod()))
+                    : new V1PodList(Collections.emptyList())
+        }
+    }
+}


### PR DESCRIPTION
This is required, since in some cases kubeconfig might be loaded with a client. But since client cannot be created before all filters are initialized, a circular dependency may occur.

@yawkat Do you know if there is a better way of doing this?

Also, in my case for some reason circular dependency was not detected, but instead this was printed endlessly. Is there some special filter logic that causes this?
```
Path Taken: new KubernetesHttpClientFactory(KubeConfigLoader kubeConfigLoader,KubernetesClientConfiguration kubernetesClientConfiguration,KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,ResourceResolver resourceResolver,DefaultHttpClientFilterResolver defaultHttpClientFilterResolver) --> new KubernetesHttpClientFactory(KubeConfigLoader kubeConfigLoader,KubernetesClientConfiguration kubernetesClientConfiguration,KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,ResourceResolver resourceResolver,[DefaultHttpClientFilterResolver defaultHttpClientFilterResolver]) --> ContainerEngineClientFactory.setProvider([HttpProvider provider]) --> new ManagedNettyHttpProvider([HttpClientRegistry<HttpClient T> mnHttpClientRegistry],ExecutorService ioExecutor,ObjectMapper jsonMapper,OciSerdeConfiguration ociSerdeConfiguration,OciSerializationConfiguration ociSerializationConfiguration,List<OciNettyClientFilter<Object R> E> nettyClientFilters)
Path Taken: new KubernetesHttpClientFactory(KubeConfigLoader kubeConfigLoader,KubernetesClientConfiguration kubernetesClientConfiguration,KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,ResourceResolver resourceResolver,DefaultHttpClientFilterResolver defaultHttpClientFilterResolver) --> new KubernetesHttpClientFactory(KubeConfigLoader kubeConfigLoader,KubernetesClientConfiguration kubernetesClientConfiguration,KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,ResourceResolver resourceResolver,[DefaultHttpClientFilterResolver defaultHttpClientFilterResolver]) --> ContainerEngineClientFactory.setProvider([HttpProvider provider]) --> new ManagedNettyHttpProvider([HttpClientRegistry<HttpClient T> mnHttpClientRegistry],ExecutorService ioExecutor,ObjectMapper jsonMapper,OciSerdeConfiguration ociSerdeConfiguration,OciSerializationConfiguration ociSerializationConfiguration,List<OciNettyClientFilter<Object R> E> nettyClientFilters)
Path Taken: new KubernetesHttpClientFactory(KubeConfigLoader kubeConfigLoader,KubernetesClientConfiguration kubernetesClientConfiguration,KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,ResourceResolver resourceResolver,DefaultHttpClientFilterResolver defaultHttpClientFilterResolver) --> new KubernetesHttpClientFactory(KubeConfigLoader kubeConfigLoader,KubernetesClientConfiguration kubernetesClientConfiguration,KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,ResourceResolver resourceResolver,[DefaultHttpClientFilterResolver defaultHttpClientFilterResolver]) --> ContainerEngineClientFactory.setProvider([HttpProvider provider]) --> new ManagedNettyHttpProvider([HttpClientRegistry<HttpClient T> mnHttpClientRegistry],ExecutorService ioExecutor,ObjectMapper jsonMapper,OciSerdeConfiguration ociSerdeConfiguration,OciSerializationConfiguration ociSerializationConfiguration,List<OciNettyClientFilter<Object R> E> nettyClientFilters)
Path Taken: new KubernetesHttpClientFactory(KubeConfigLoader kubeConfigLoader,KubernetesClientConfiguration kubernetesClientConfiguration,KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,ResourceResolver resourceResolver,DefaultHttpClientFilterResolver defaultHttpClientFilterResolver) --> new KubernetesHttpClientFactory(KubeConfigLoader kubeConfigLoader,KubernetesClientConfiguration kubernetesClientConfiguration,KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,ResourceResolver resourceResolver,[DefaultHttpClientFilterResolver defaultHttpClientFilterResolver]) --> ContainerEngineClientFactory.setProvider([HttpProvider provider]) --> new ManagedNettyHttpProvider([HttpClientRegistry<HttpClient T> mnHttpClientRegistry],ExecutorService ioExecutor,ObjectMapper jsonMapper,OciSerdeConfiguration ociSerdeConfiguration,OciSerializationConfiguration ociSerializationConfiguration,List<OciNettyClientFilter<Object R> E> nettyClientFilters)
...
```

