### PR TITLE
Clarify what file client config configurations are added to

### DIFF
--- a/src/main/docs/guide/config-client.adoc
+++ b/src/main/docs/guide/config-client.adoc
@@ -25,7 +25,7 @@ Supported formats for ``ConfigMap``s are:
 
 The configuration client by default will read all the ``ConfigMap``s for the configured namespace. You can further filter
 which config map names are processed by defining `kubernetes.client.config-maps.includes` or
-`kubernetes.client.config-maps.excludes`:
+`kubernetes.client.config-maps.excludes` in `bootstrap.yml`:
 
 [source,yaml]
 ----
@@ -135,7 +135,7 @@ This will make Kubernetes to create file per data entry:
 
 While you could potentially use the `java.io` or `java.nio` APIs to read the contents yourself, this configuration module
 can convert them into a ``PropertySource`` so that you can consume the values much more easily. In order to do so, define
-the following configuration:
+the following configuration in `bootstrap.yml`:
 
 [source,yaml]
 ----
@@ -223,7 +223,7 @@ kubernetes:
 ----
 
 The configuration client, by default, will read all the ``Secret``s for the configured namespace. You can further filter
-which config map names are processed by defining `kubernetes.client.secrets.includes` or `kubernetes.client.secrets.excludes`:
+which config map names are processed by defining `kubernetes.client.secrets.includes` or `kubernetes.client.secrets.excludes` in `bootstrap.yml`:
 
 [source,yaml]
 ----

--- a/src/main/docs/guide/config-client.adoc
+++ b/src/main/docs/guide/config-client.adoc
@@ -223,7 +223,8 @@ kubernetes:
 ----
 
 The configuration client, by default, will read all the ``Secret``s for the configured namespace. You can further filter
-which config map names are processed by defining `kubernetes.client.secrets.includes` or `kubernetes.client.secrets.excludes` in `bootstrap.yml`:
+which config map names are processed by defining `kubernetes.client.secrets.includes` or `kubernetes.client.secrets.excludes` in https://docs.micronaut.io/latest/guide/#bootstrap[bootstrap configuration]:
+
 
 [source,yaml]
 ----

--- a/src/main/docs/guide/config-client.adoc
+++ b/src/main/docs/guide/config-client.adoc
@@ -137,7 +137,7 @@ While you could potentially use the `java.io` or `java.nio` APIs to read the con
 can convert them into a ``PropertySource`` so that you can consume the values much more easily. In order to do so, define
 the following configuration in https://docs.micronaut.io/latest/guide/#bootstrap[bootstrap configuration]:
 
-[source,yaml]
+[configuration]
 ----
 kubernetes:
   client:

--- a/src/main/docs/guide/config-client.adoc
+++ b/src/main/docs/guide/config-client.adoc
@@ -27,7 +27,7 @@ The configuration client by default will read all the ``ConfigMap``s for the con
 which config map names are processed by defining `kubernetes.client.config-maps.includes` or
 `kubernetes.client.config-maps.excludes` in https://docs.micronaut.io/latest/guide/#bootstrap[bootstrap configuration]:
 
-[source,yaml]
+[configuration]
 ----
 kubernetes:
   client:

--- a/src/main/docs/guide/config-client.adoc
+++ b/src/main/docs/guide/config-client.adoc
@@ -226,7 +226,7 @@ The configuration client, by default, will read all the ``Secret``s for the conf
 which config map names are processed by defining `kubernetes.client.secrets.includes` or `kubernetes.client.secrets.excludes` in https://docs.micronaut.io/latest/guide/#bootstrap[bootstrap configuration]:
 
 
-[source,yaml]
+[configuration]
 ----
 kubernetes:
   client:

--- a/src/main/docs/guide/config-client.adoc
+++ b/src/main/docs/guide/config-client.adoc
@@ -135,7 +135,7 @@ This will make Kubernetes to create file per data entry:
 
 While you could potentially use the `java.io` or `java.nio` APIs to read the contents yourself, this configuration module
 can convert them into a ``PropertySource`` so that you can consume the values much more easily. In order to do so, define
-the following configuration in `bootstrap.yml`:
+the following configuration in https://docs.micronaut.io/latest/guide/#bootstrap[bootstrap configuration]:
 
 [source,yaml]
 ----

--- a/src/main/docs/guide/config-client.adoc
+++ b/src/main/docs/guide/config-client.adoc
@@ -25,7 +25,7 @@ Supported formats for ``ConfigMap``s are:
 
 The configuration client by default will read all the ``ConfigMap``s for the configured namespace. You can further filter
 which config map names are processed by defining `kubernetes.client.config-maps.includes` or
-`kubernetes.client.config-maps.excludes` in `bootstrap.yml`:
+`kubernetes.client.config-maps.excludes` in https://docs.micronaut.io/latest/guide/#bootstrap[bootstrap configuration]:
 
 [source,yaml]
 ----


### PR DESCRIPTION
When working with Spring or Micronaut, the default place to add configuration changes is to application.yml. It was unclear that this config should be added in the bootstrap file.