### PR TITLE
Downgraded micronaut-gradle-plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ micronaut = "4.8.1"
 micronaut-platform = "4.7.5"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.7.0"
-micronaut-gradle-plugin = "4.4.5"
+micronaut-gradle-plugin = "4.4.4"
 
 graal-svm = "24.0.2"
 javapoet = '1.13.0'

--- a/kubernetes-client-openapi-watcher/src/test/groovy/io/micronaut/kubernetes/client/openapi/watcher/WatchEventsSpec.groovy
+++ b/kubernetes-client-openapi-watcher/src/test/groovy/io/micronaut/kubernetes/client/openapi/watcher/WatchEventsSpec.groovy
@@ -127,6 +127,6 @@ class WatchEventsSpec extends Specification implements TestPropertyProvider {
     }
 
     private V1Status deleteSecret(String namespaceName, String secretName) {
-        return api.deleteNamespacedSecret(secretName, namespaceName, null, null, null, null, null, null).body()
+        api.deleteNamespacedSecret(secretName, namespaceName, null, null, null, null, null, null)
     }
 }


### PR DESCRIPTION
The `micronaut-gradle-plugin` upgrade from `4.4.4` to `4.4.5` has introduced a breaking change caused by this [commit](https://github.com/micronaut-projects/micronaut-gradle-plugin/pull/1052). Since the default value for `generateHttpResponseWhereRequired` was changed from `false` to `true` the generated api code was modified which caused issues with current implementation for kubernetes openapi modules