### PR TITLE
Kubernetes openapi client - http client configuration

### DIFF
--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFactory.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFactory.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.kubernetes.client.openapi;
 
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Factory;
@@ -27,6 +28,7 @@ import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.bind.DefaultRequestBinderRegistry;
 import io.micronaut.http.body.MessageBodyHandlerRegistry;
+import io.micronaut.http.client.DefaultHttpClientConfiguration;
 import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.client.LoadBalancer;
 import io.micronaut.http.client.filter.ClientFilterResolutionContext;
@@ -34,6 +36,7 @@ import io.micronaut.http.client.filter.DefaultHttpClientFilterResolver;
 import io.micronaut.http.client.netty.DefaultHttpClient;
 import io.micronaut.http.client.netty.NettyClientCustomizer;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfig;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfigLoader;
 import io.micronaut.kubernetes.client.openapi.config.KubernetesClientConfiguration;
@@ -66,7 +69,7 @@ import java.util.Optional;
 @Requires(beans = KubernetesClientConfiguration.class)
 final class KubernetesHttpClientFactory {
 
-    static final String CLIENT_ID = "kubernetes-client";
+    static final String CLIENT_ID = "kubernetes";
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesHttpClientFactory.class);
     private static final String ENV_SERVICE_HOST = "KUBERNETES_SERVICE_HOST";
     private static final String ENV_SERVICE_PORT = "KUBERNETES_SERVICE_PORT";
@@ -84,18 +87,24 @@ final class KubernetesHttpClientFactory {
                                 KubernetesClientConfiguration kubernetesClientConfiguration,
                                 KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,
                                 ResourceResolver resourceResolver,
-                                HttpClientConfiguration httpClientConfiguration,
                                 DefaultHttpClientFilterResolver defaultHttpClientFilterResolver,
                                 MessageBodyHandlerRegistry messageBodyHandlerRegistry,
-                                MediaTypeCodecRegistry mediaTypeCodecRegistry) {
+                                MediaTypeCodecRegistry mediaTypeCodecRegistry,
+                                ApplicationContext applicationContext) {
         kubeConfig = kubeConfigLoader.getKubeConfig();
         this.kubernetesClientConfiguration = kubernetesClientConfiguration;
         this.kubernetesPrivateKeyLoader = kubernetesPrivateKeyLoader;
         this.resourceResolver = resourceResolver;
-        this.httpClientConfiguration = httpClientConfiguration;
         this.defaultHttpClientFilterResolver = defaultHttpClientFilterResolver;
         this.messageBodyHandlerRegistry = messageBodyHandlerRegistry;
         this.mediaTypeCodecRegistry = mediaTypeCodecRegistry;
+        httpClientConfiguration = applicationContext.findBean(HttpClientConfiguration.class, Qualifiers.byName(CLIENT_ID))
+            .orElse(new DefaultHttpClientConfiguration());
+        Optional<Duration> readTimeout = httpClientConfiguration.getReadTimeout();
+        if (readTimeout.isPresent()) {
+            httpClientConfiguration.setRequestTimeout(readTimeout.get().plusSeconds(1));
+            httpClientConfiguration.setReadTimeout(Duration.ZERO);
+        }
     }
 
     @Singleton
@@ -119,11 +128,6 @@ final class KubernetesHttpClientFactory {
             uri = new URI("https", null, host, Integer.parseInt(port), null, null, null);
         } else {
             throw new ConfigurationException("Kube config not provided nor service account authentication enabled");
-        }
-        Optional<Duration> readTimeout = httpClientConfiguration.getReadTimeout();
-        if (readTimeout.isPresent()) {
-            httpClientConfiguration.setRequestTimeout(readTimeout.get().plusSeconds(1));
-            httpClientConfiguration.setReadTimeout(Duration.ZERO);
         }
         return new DefaultHttpClient(LoadBalancer.fixed(uri),
             null,

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFactory.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFactory.java
@@ -27,7 +27,7 @@ import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.bind.DefaultRequestBinderRegistry;
 import io.micronaut.http.body.MessageBodyHandlerRegistry;
-import io.micronaut.http.client.DefaultHttpClientConfiguration;
+import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.client.LoadBalancer;
 import io.micronaut.http.client.filter.ClientFilterResolutionContext;
 import io.micronaut.http.client.filter.DefaultHttpClientFilterResolver;
@@ -75,6 +75,7 @@ final class KubernetesHttpClientFactory {
     private final KubernetesClientConfiguration kubernetesClientConfiguration;
     private final KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader;
     private final ResourceResolver resourceResolver;
+    private final HttpClientConfiguration httpClientConfiguration;
     private final DefaultHttpClientFilterResolver defaultHttpClientFilterResolver;
     private final MessageBodyHandlerRegistry messageBodyHandlerRegistry;
     private final MediaTypeCodecRegistry mediaTypeCodecRegistry;
@@ -83,6 +84,7 @@ final class KubernetesHttpClientFactory {
                                 KubernetesClientConfiguration kubernetesClientConfiguration,
                                 KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,
                                 ResourceResolver resourceResolver,
+                                HttpClientConfiguration httpClientConfiguration,
                                 DefaultHttpClientFilterResolver defaultHttpClientFilterResolver,
                                 MessageBodyHandlerRegistry messageBodyHandlerRegistry,
                                 MediaTypeCodecRegistry mediaTypeCodecRegistry) {
@@ -90,6 +92,7 @@ final class KubernetesHttpClientFactory {
         this.kubernetesClientConfiguration = kubernetesClientConfiguration;
         this.kubernetesPrivateKeyLoader = kubernetesPrivateKeyLoader;
         this.resourceResolver = resourceResolver;
+        this.httpClientConfiguration = httpClientConfiguration;
         this.defaultHttpClientFilterResolver = defaultHttpClientFilterResolver;
         this.messageBodyHandlerRegistry = messageBodyHandlerRegistry;
         this.mediaTypeCodecRegistry = mediaTypeCodecRegistry;
@@ -117,7 +120,6 @@ final class KubernetesHttpClientFactory {
         } else {
             throw new ConfigurationException("Kube config not provided nor service account authentication enabled");
         }
-        DefaultHttpClientConfiguration httpClientConfiguration = new DefaultHttpClientConfiguration();
         Optional<Duration> readTimeout = httpClientConfiguration.getReadTimeout();
         if (readTimeout.isPresent()) {
             httpClientConfiguration.setRequestTimeout(readTimeout.get().plusSeconds(1));

--- a/kubernetes-client-openapi-reactor/build.gradle
+++ b/kubernetes-client-openapi-reactor/build.gradle
@@ -16,7 +16,7 @@ micronaut {
             apiPackageName = "io.micronaut.kubernetes.client.openapi.reactor.api"
             modelPackageName = "io.micronaut.kubernetes.client.openapi.model"
             apiNameSuffix = "ApiReactor"
-            clientId = "kubernetes-client"
+            clientId = "kubernetes"
             useReactive = true
             additionalClientTypeAnnotations = [
                     "@io.micronaut.kubernetes.client.openapi.reactor.annotation.KubernetesClientApiReactor",

--- a/kubernetes-client-openapi-watcher/build.gradle
+++ b/kubernetes-client-openapi-watcher/build.gradle
@@ -23,7 +23,7 @@ micronaut {
             apiPackageName = "io.micronaut.kubernetes.client.openapi.watcher.api"
             modelPackageName = "io.micronaut.kubernetes.client.openapi.model"
             apiNameSuffix = "ApiWatcher"
-            clientId = "kubernetes-client"
+            clientId = "kubernetes"
             useReactive = true
             fluxForArrays = true
             typeMapping = tasks.named("createWatcherOpenApiSpec", CreateWatcherSpec).flatMap(CreateWatcherSpec::getWatcherTypeMappingsFile).map { t->

--- a/kubernetes-client-openapi/build.gradle
+++ b/kubernetes-client-openapi/build.gradle
@@ -15,7 +15,7 @@ micronaut {
         client("client", tasks.named("downloadOpenApiSpec", DownloadSpec).flatMap(DownloadSpec::getSpecFile)) {
             apiPackageName = "io.micronaut.kubernetes.client.openapi.api"
             modelPackageName = "io.micronaut.kubernetes.client.openapi.model"
-            clientId = "kubernetes-client"
+            clientId = "kubernetes"
             useReactive = false
             additionalClientTypeAnnotations = [
                     "@io.micronaut.context.annotation.BootstrapContextCompatible"


### PR DESCRIPTION
Modified the kubernetes openapi client to use the http client configuration from:
- `ServiceHttpClientConfiguration` (if `micronaut.http.services.kubernetes` config is provided)
- `DefaultHttpClientConfiguration` (a new instance of that class when the above mentioned config is not provided)

Config example:
```
micronaut:
  http:
    services:
      kubernetes:
        pool:
          maxPendingConnections: 6
```

Also modified kubernetes service/client id from `kubernetes-client` to `kubernetes`