### PR TITLE
Http client configuration for kubernetes openapi client

### DIFF
--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientConfiguration.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientConfiguration.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kubernetes.client.openapi;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.client.DefaultHttpClientConfiguration;
+import io.micronaut.http.client.HttpClientConfiguration;
+import io.micronaut.http.ssl.ClientSslConfiguration;
+import io.micronaut.runtime.ApplicationConfiguration;
+import jakarta.inject.Inject;
+
+@BootstrapContextCompatible
+@ConfigurationProperties(KubernetesHttpClientConfiguration.PREFIX)
+final class KubernetesHttpClientConfiguration extends HttpClientConfiguration {
+
+    static final String PREFIX = "micronaut.http.client.kubernetes";
+
+    private final ConnectionPoolConfiguration connectionPoolConfiguration;
+
+    private final WebSocketCompressionConfiguration webSocketCompressionConfiguration;
+
+    private final Http2ClientConfiguration http2ClientConfiguration;
+
+    KubernetesHttpClientConfiguration(@Nullable DefaultHttpClientConfiguration.DefaultConnectionPoolConfiguration defaultConnectionPoolConfiguration,
+                                      @Nullable DefaultHttpClientConfiguration.DefaultWebSocketCompressionConfiguration defaultWebSocketCompressionConfiguration,
+                                      @Nullable DefaultHttpClientConfiguration.DefaultHttp2ClientConfiguration defaultHttp2ClientConfiguration,
+                                      @Nullable ApplicationConfiguration applicationConfiguration) {
+        super(applicationConfiguration);
+        connectionPoolConfiguration = defaultConnectionPoolConfiguration == null
+            ? new DefaultHttpClientConfiguration.DefaultConnectionPoolConfiguration()
+            : defaultConnectionPoolConfiguration;
+        webSocketCompressionConfiguration = defaultWebSocketCompressionConfiguration == null
+            ? new DefaultHttpClientConfiguration.DefaultWebSocketCompressionConfiguration()
+            : defaultWebSocketCompressionConfiguration;
+        http2ClientConfiguration = defaultHttp2ClientConfiguration == null
+            ? new DefaultHttpClientConfiguration.DefaultHttp2ClientConfiguration()
+            : defaultHttp2ClientConfiguration;
+    }
+
+    /**
+     * Uses the default SSL configuration.
+     *
+     * @param sslConfiguration The SSL configuration
+     */
+    @Inject
+    public void setClientSslConfiguration(@Nullable ClientSslConfiguration sslConfiguration) {
+        if (sslConfiguration != null) {
+            super.setSslConfiguration(sslConfiguration);
+        }
+    }
+
+    @Override
+    public ConnectionPoolConfiguration getConnectionPoolConfiguration() {
+        return connectionPoolConfiguration;
+    }
+
+    @Override
+    public WebSocketCompressionConfiguration getWebSocketCompressionConfiguration() {
+        return webSocketCompressionConfiguration;
+    }
+
+    @Override
+    public Http2ClientConfiguration getHttp2Configuration() {
+        return http2ClientConfiguration;
+    }
+}

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFactory.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFactory.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.kubernetes.client.openapi;
 
-import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Factory;
@@ -28,15 +27,12 @@ import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.bind.DefaultRequestBinderRegistry;
 import io.micronaut.http.body.MessageBodyHandlerRegistry;
-import io.micronaut.http.client.DefaultHttpClientConfiguration;
-import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.client.LoadBalancer;
 import io.micronaut.http.client.filter.ClientFilterResolutionContext;
 import io.micronaut.http.client.filter.DefaultHttpClientFilterResolver;
 import io.micronaut.http.client.netty.DefaultHttpClient;
 import io.micronaut.http.client.netty.NettyClientCustomizer;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
-import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfig;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfigLoader;
 import io.micronaut.kubernetes.client.openapi.config.KubernetesClientConfiguration;
@@ -78,19 +74,19 @@ final class KubernetesHttpClientFactory {
     private final KubernetesClientConfiguration kubernetesClientConfiguration;
     private final KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader;
     private final ResourceResolver resourceResolver;
-    private final HttpClientConfiguration httpClientConfiguration;
+    private final KubernetesHttpClientConfiguration kubernetesHttpClientConfiguration;
     private final DefaultHttpClientFilterResolver defaultHttpClientFilterResolver;
     private final MessageBodyHandlerRegistry messageBodyHandlerRegistry;
     private final MediaTypeCodecRegistry mediaTypeCodecRegistry;
 
     KubernetesHttpClientFactory(KubeConfigLoader kubeConfigLoader,
                                 KubernetesClientConfiguration kubernetesClientConfiguration,
+                                KubernetesHttpClientConfiguration kubernetesHttpClientConfiguration,
                                 KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,
                                 ResourceResolver resourceResolver,
                                 DefaultHttpClientFilterResolver defaultHttpClientFilterResolver,
                                 MessageBodyHandlerRegistry messageBodyHandlerRegistry,
-                                MediaTypeCodecRegistry mediaTypeCodecRegistry,
-                                ApplicationContext applicationContext) {
+                                MediaTypeCodecRegistry mediaTypeCodecRegistry) {
         kubeConfig = kubeConfigLoader.getKubeConfig();
         this.kubernetesClientConfiguration = kubernetesClientConfiguration;
         this.kubernetesPrivateKeyLoader = kubernetesPrivateKeyLoader;
@@ -98,13 +94,7 @@ final class KubernetesHttpClientFactory {
         this.defaultHttpClientFilterResolver = defaultHttpClientFilterResolver;
         this.messageBodyHandlerRegistry = messageBodyHandlerRegistry;
         this.mediaTypeCodecRegistry = mediaTypeCodecRegistry;
-        httpClientConfiguration = applicationContext.findBean(HttpClientConfiguration.class, Qualifiers.byName(CLIENT_ID))
-            .orElse(new DefaultHttpClientConfiguration());
-        Optional<Duration> readTimeout = httpClientConfiguration.getReadTimeout();
-        if (readTimeout.isPresent()) {
-            httpClientConfiguration.setRequestTimeout(readTimeout.get().plusSeconds(1));
-            httpClientConfiguration.setReadTimeout(Duration.ZERO);
-        }
+        this.kubernetesHttpClientConfiguration = kubernetesHttpClientConfiguration;
     }
 
     @Singleton
@@ -129,9 +119,14 @@ final class KubernetesHttpClientFactory {
         } else {
             throw new ConfigurationException("Kube config not provided nor service account authentication enabled");
         }
+        Optional<Duration> readTimeout = kubernetesHttpClientConfiguration.getReadTimeout();
+        if (readTimeout.isPresent()) {
+            kubernetesHttpClientConfiguration.setRequestTimeout(readTimeout.get().plusSeconds(1));
+            kubernetesHttpClientConfiguration.setReadTimeout(Duration.ZERO);
+        }
         return new DefaultHttpClient(LoadBalancer.fixed(uri),
             null,
-            httpClientConfiguration,
+            kubernetesHttpClientConfiguration,
             null,
             defaultHttpClientFilterResolver,
             defaultHttpClientFilterResolver.resolveFilterEntries(new ClientFilterResolutionContext(Collections.singletonList(CLIENT_ID), null)),

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFactory.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFactory.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.kubernetes.client.openapi;
 
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Factory;
@@ -27,6 +28,7 @@ import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.bind.DefaultRequestBinderRegistry;
 import io.micronaut.http.body.MessageBodyHandlerRegistry;
+import io.micronaut.http.client.DefaultHttpClientConfiguration;
 import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.client.LoadBalancer;
 import io.micronaut.http.client.filter.ClientFilterResolutionContext;
@@ -34,6 +36,7 @@ import io.micronaut.http.client.filter.DefaultHttpClientFilterResolver;
 import io.micronaut.http.client.netty.DefaultHttpClient;
 import io.micronaut.http.client.netty.NettyClientCustomizer;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfig;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfigLoader;
 import io.micronaut.kubernetes.client.openapi.config.KubernetesClientConfiguration;
@@ -66,7 +69,7 @@ import java.util.Optional;
 @Requires(beans = KubernetesClientConfiguration.class)
 final class KubernetesHttpClientFactory {
 
-    static final String CLIENT_ID = "kubernetes-client";
+    static final String CLIENT_ID = "kubernetes";
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesHttpClientFactory.class);
     private static final String ENV_SERVICE_HOST = "KUBERNETES_SERVICE_HOST";
     private static final String ENV_SERVICE_PORT = "KUBERNETES_SERVICE_PORT";
@@ -84,18 +87,24 @@ final class KubernetesHttpClientFactory {
                                 KubernetesClientConfiguration kubernetesClientConfiguration,
                                 KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,
                                 ResourceResolver resourceResolver,
-                                HttpClientConfiguration httpClientConfiguration,
                                 DefaultHttpClientFilterResolver defaultHttpClientFilterResolver,
                                 MessageBodyHandlerRegistry messageBodyHandlerRegistry,
-                                MediaTypeCodecRegistry mediaTypeCodecRegistry) {
+                                MediaTypeCodecRegistry mediaTypeCodecRegistry,
+                                ApplicationContext applicationContext) {
         kubeConfig = kubeConfigLoader.getKubeConfig();
         this.kubernetesClientConfiguration = kubernetesClientConfiguration;
         this.kubernetesPrivateKeyLoader = kubernetesPrivateKeyLoader;
         this.resourceResolver = resourceResolver;
-        this.httpClientConfiguration = httpClientConfiguration;
         this.defaultHttpClientFilterResolver = defaultHttpClientFilterResolver;
         this.messageBodyHandlerRegistry = messageBodyHandlerRegistry;
         this.mediaTypeCodecRegistry = mediaTypeCodecRegistry;
+        httpClientConfiguration = applicationContext.findBean(HttpClientConfiguration.class, Qualifiers.byName(CLIENT_ID))
+            .orElse(new DefaultHttpClientConfiguration());
+        Optional<Duration> readTimeout = httpClientConfiguration.getReadTimeout();
+        if (readTimeout.isPresent()) {
+            httpClientConfiguration.setRequestTimeout(readTimeout.get().plusSeconds(1));
+            httpClientConfiguration.setReadTimeout(Duration.ZERO);
+        }
     }
 
     @Singleton
@@ -119,11 +128,6 @@ final class KubernetesHttpClientFactory {
             uri = new URI("https", null, host, Integer.parseInt(port), null, null, null);
         } else {
             throw new ConfigurationException("Kube config not provided nor service account authentication enabled");
-        }
-        Optional<Duration> readTimeout = httpClientConfiguration.getReadTimeout();
-        if (readTimeout.isPresent()) {
-            httpClientConfiguration.setRequestTimeout(readTimeout.get().plusSeconds(1));
-            httpClientConfiguration.setReadTimeout(Duration.ZERO);
         }
         return new DefaultHttpClient(LoadBalancer.fixed(uri),
             null,

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFactory.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFactory.java
@@ -27,7 +27,7 @@ import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.bind.DefaultRequestBinderRegistry;
 import io.micronaut.http.body.MessageBodyHandlerRegistry;
-import io.micronaut.http.client.DefaultHttpClientConfiguration;
+import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.client.LoadBalancer;
 import io.micronaut.http.client.filter.ClientFilterResolutionContext;
 import io.micronaut.http.client.filter.DefaultHttpClientFilterResolver;
@@ -75,6 +75,7 @@ final class KubernetesHttpClientFactory {
     private final KubernetesClientConfiguration kubernetesClientConfiguration;
     private final KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader;
     private final ResourceResolver resourceResolver;
+    private final HttpClientConfiguration httpClientConfiguration;
     private final DefaultHttpClientFilterResolver defaultHttpClientFilterResolver;
     private final MessageBodyHandlerRegistry messageBodyHandlerRegistry;
     private final MediaTypeCodecRegistry mediaTypeCodecRegistry;
@@ -83,6 +84,7 @@ final class KubernetesHttpClientFactory {
                                 KubernetesClientConfiguration kubernetesClientConfiguration,
                                 KubernetesPrivateKeyLoader kubernetesPrivateKeyLoader,
                                 ResourceResolver resourceResolver,
+                                HttpClientConfiguration httpClientConfiguration,
                                 DefaultHttpClientFilterResolver defaultHttpClientFilterResolver,
                                 MessageBodyHandlerRegistry messageBodyHandlerRegistry,
                                 MediaTypeCodecRegistry mediaTypeCodecRegistry) {
@@ -90,6 +92,7 @@ final class KubernetesHttpClientFactory {
         this.kubernetesClientConfiguration = kubernetesClientConfiguration;
         this.kubernetesPrivateKeyLoader = kubernetesPrivateKeyLoader;
         this.resourceResolver = resourceResolver;
+        this.httpClientConfiguration = httpClientConfiguration;
         this.defaultHttpClientFilterResolver = defaultHttpClientFilterResolver;
         this.messageBodyHandlerRegistry = messageBodyHandlerRegistry;
         this.mediaTypeCodecRegistry = mediaTypeCodecRegistry;
@@ -117,7 +120,6 @@ final class KubernetesHttpClientFactory {
         } else {
             throw new ConfigurationException("Kube config not provided nor service account authentication enabled");
         }
-        DefaultHttpClientConfiguration httpClientConfiguration = new DefaultHttpClientConfiguration();
         Optional<Duration> readTimeout = httpClientConfiguration.getReadTimeout();
         if (readTimeout.isPresent()) {
             httpClientConfiguration.setRequestTimeout(readTimeout.get().plusSeconds(1));

--- a/kubernetes-client-openapi-reactor/build.gradle
+++ b/kubernetes-client-openapi-reactor/build.gradle
@@ -16,7 +16,7 @@ micronaut {
             apiPackageName = "io.micronaut.kubernetes.client.openapi.reactor.api"
             modelPackageName = "io.micronaut.kubernetes.client.openapi.model"
             apiNameSuffix = "ApiReactor"
-            clientId = "kubernetes-client"
+            clientId = "kubernetes"
             useReactive = true
             additionalClientTypeAnnotations = [
                     "@io.micronaut.kubernetes.client.openapi.reactor.annotation.KubernetesClientApiReactor",

--- a/kubernetes-client-openapi-watcher/build.gradle
+++ b/kubernetes-client-openapi-watcher/build.gradle
@@ -23,7 +23,7 @@ micronaut {
             apiPackageName = "io.micronaut.kubernetes.client.openapi.watcher.api"
             modelPackageName = "io.micronaut.kubernetes.client.openapi.model"
             apiNameSuffix = "ApiWatcher"
-            clientId = "kubernetes-client"
+            clientId = "kubernetes"
             useReactive = true
             fluxForArrays = true
             typeMapping = tasks.named("createWatcherOpenApiSpec", CreateWatcherSpec).flatMap(CreateWatcherSpec::getWatcherTypeMappingsFile).map { t->

--- a/kubernetes-client-openapi/build.gradle
+++ b/kubernetes-client-openapi/build.gradle
@@ -15,7 +15,7 @@ micronaut {
         client("client", tasks.named("downloadOpenApiSpec", DownloadSpec).flatMap(DownloadSpec::getSpecFile)) {
             apiPackageName = "io.micronaut.kubernetes.client.openapi.api"
             modelPackageName = "io.micronaut.kubernetes.client.openapi.model"
-            clientId = "kubernetes-client"
+            clientId = "kubernetes"
             useReactive = false
             additionalClientTypeAnnotations = [
                     "@io.micronaut.context.annotation.BootstrapContextCompatible"


### PR DESCRIPTION
@graemerocher @yawkat - I closed the previous and created a new PR for kubernetes http client configuration. We can't use `ServiceHttpClientConfiguration` for kubernetes client since it doesn't have `@BootstrapContextCompatible` annotation, so I created a new http client config class: `KubernetesHttpClientConfiguration`. The new class uses the following managed beans if those were created, otherwise creates new ones:
- DefaultConnectionPoolConfiguration
- DefaultWebSocketCompressionConfiguration
- DefaultHttp2ClientConfiguration
- ClientSslConfiguration

So all those config settings will be the same as for other http clients. So only properties from `HttpClientConfiguration` class can be customized for kubernetes http client comparing to other http clients since we need to set request timeouts for streaming on the following way:
```
        Optional<Duration> readTimeout = kubernetesHttpClientConfiguration.getReadTimeout();
        if (readTimeout.isPresent()) {
            kubernetesHttpClientConfiguration.setRequestTimeout(readTimeout.get().plusSeconds(1));
            kubernetesHttpClientConfiguration.setReadTimeout(Duration.ZERO);
        }
```
Does this seem ok to you?