### PR TITLE
Additional logging in kubernetes config watchers

### DIFF
--- a/kubernetes-client-openapi-discovery/src/main/java/io/micronaut/kubernetes/client/openapi/configuration/AbstractKubernetesConfigWatcher.java
+++ b/kubernetes-client-openapi-discovery/src/main/java/io/micronaut/kubernetes/client/openapi/configuration/AbstractKubernetesConfigWatcher.java
@@ -68,6 +68,10 @@ abstract sealed class AbstractKubernetesConfigWatcher<T extends KubernetesObject
     @Override
     public void onAdd(T object) {
         if (!serviceStarted.get()) {
+            LOG.trace("Skipped processing of added kubernetes object since service not started yet, objectName={}, objectType={}, resourceVersion={}",
+                object.getMetadata().getName(),
+                object.getClass().getSimpleName(),
+                object.getMetadata().getResourceVersion());
             return;
         }
         LOG.trace("Started processing of added kubernetes object, objectName={}, objectType={}, resourceVersion={}",
@@ -89,6 +93,10 @@ abstract sealed class AbstractKubernetesConfigWatcher<T extends KubernetesObject
     @Override
     public void onUpdate(T oldObject, T newObject) {
         if (!serviceStarted.get()) {
+            LOG.trace("Skipped processing of modified kubernetes object since service not started yet, objectName={}, objectType={}, resourceVersion={}",
+                newObject.getMetadata().getName(),
+                newObject.getClass().getSimpleName(),
+                newObject.getMetadata().getResourceVersion());
             return;
         }
         LOG.trace("Started processing of modified kubernetes object, objectName={}, objectType={}, resourceVersion={}",
@@ -110,6 +118,10 @@ abstract sealed class AbstractKubernetesConfigWatcher<T extends KubernetesObject
     @Override
     public void onDelete(T object, boolean deletedFinalStateUnknown) {
         if (!serviceStarted.get()) {
+            LOG.trace("Skipped processing of deleted kubernetes object since service not started yet, objectName={}, objectType={}, resourceVersion={}",
+                object.getMetadata().getName(),
+                object.getClass().getSimpleName(),
+                object.getMetadata().getResourceVersion());
             return;
         }
         LOG.trace("Started processing of deleted kubernetes object, objectName={}, objectType={}, resourceVersion={}",

--- a/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/AbstractKubernetesConfigWatcher.java
+++ b/kubernetes-discovery-client/src/main/java/io/micronaut/kubernetes/configuration/AbstractKubernetesConfigWatcher.java
@@ -58,6 +58,10 @@ public abstract class AbstractKubernetesConfigWatcher<T extends KubernetesObject
     @Override
     public void onAdd(T config) {
         if (!serviceStarted.get()) {
+            LOG.trace("Skipped processing of added kubernetes object since service not started yet, objectName={}, objectType={}, resourceVersion={}",
+                config.getMetadata().getName(),
+                config.getClass().getSimpleName(),
+                config.getMetadata().getResourceVersion());
             return;
         }
 
@@ -80,6 +84,10 @@ public abstract class AbstractKubernetesConfigWatcher<T extends KubernetesObject
     @Override
     public void onUpdate(T oldConfig, T newConfig) {
         if (!serviceStarted.get()) {
+            LOG.trace("Skipped processing of modified kubernetes object since service not started yet, objectName={}, objectType={}, resourceVersion={}",
+                newConfig.getMetadata().getName(),
+                newConfig.getClass().getSimpleName(),
+                newConfig.getMetadata().getResourceVersion());
             return;
         }
         PropertySource propertySource = null;
@@ -100,6 +108,10 @@ public abstract class AbstractKubernetesConfigWatcher<T extends KubernetesObject
     @Override
     public void onDelete(T config, boolean deletedFinalStateUnknown) {
         if (!serviceStarted.get()) {
+            LOG.trace("Skipped processing of deleted kubernetes object since service not started yet, objectName={}, objectType={}, resourceVersion={}",
+                config.getMetadata().getName(),
+                config.getClass().getSimpleName(),
+                config.getMetadata().getResourceVersion());
             return;
         }
         PropertySource propertySource = null;


### PR DESCRIPTION
Added 'trace' log level messages when processing of event is skipped because service not started yet