### PR TITLE
Kubernetes openapi http client filter modifications

### DIFF
--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
@@ -70,14 +70,16 @@ final class KubernetesHttpClientFilter implements HttpClientFilter {
         if (kubeConfig != null && kubeConfig.getUser() != null) {
             AuthInfo user = kubeConfig.getUser();
             if (user.clientCertificateData() != null && user.clientKeyData() != null) {
+                LOG.trace("Using client certificate authentication");
                 return chain.proceed(request);
             }
             if (StringUtils.isNotEmpty(user.username()) && StringUtils.isNotEmpty(user.password())) {
+                LOG.trace("Using username and password authentication");
                 return chain.proceed(request.basicAuth(user.username(), user.password()));
             }
         }
         Collection<KubernetesTokenLoader> loaders = kubernetesTokenLoaders.get();
-        LOG.trace("Registered token loaders: {}", loaders);
+        LOG.trace("Using token authentication, tokenLoaders={}", loaders);
         return Flux.fromIterable(loaders)
             .concatMap(KubernetesTokenLoader::getToken)
             .next()

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
@@ -76,14 +76,19 @@ final class KubernetesHttpClientFilter implements HttpClientFilter {
                 return chain.proceed(request.basicAuth(user.username(), user.password()));
             }
         }
-
-        Mono<String> token = Flux.fromIterable(kubernetesTokenLoaders.get())
-            .doOnNext(tokenLoader -> LOG.trace("Trying to load token, loader={}", tokenLoader.getClass().getName()))
+        Collection<KubernetesTokenLoader> loaders = kubernetesTokenLoaders.get();
+        LOG.trace("Registered token loaders: {}", loaders);
+        return Flux.fromIterable(loaders)
             .concatMap(KubernetesTokenLoader::getToken)
-            .doOnNext(tokenLoader -> LOG.trace("aaaa, loader={}", tokenLoader.getClass().getName()))
             .next()
-            .doOnNext(tokenLoader -> LOG.trace("bbb, loader={}", tokenLoader.getClass().getName()));
-
-        return token.flatMapMany(t -> chain.proceed(request.bearerAuth(t)));
+            .switchIfEmpty(Mono.just(StringUtils.EMPTY_STRING))
+            .doOnNext(token -> {
+                if (StringUtils.isEmpty(token)) {
+                    LOG.trace("Token not loaded by any token loader");
+                } else {
+                    LOG.trace("Token loaded");
+                }
+            })
+            .flatMapMany(token -> StringUtils.isEmpty(token) ? chain.proceed(request) : chain.proceed(request.bearerAuth(token)));
     }
 }

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
@@ -33,6 +33,10 @@ import io.micronaut.kubernetes.client.openapi.config.model.AuthInfo;
 import io.micronaut.kubernetes.client.openapi.credential.KubernetesTokenLoader;
 import jakarta.inject.Provider;
 import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.Collection;
 
@@ -45,6 +49,7 @@ import java.util.Collection;
 @BootstrapContextCompatible
 @Filter(patterns = Filter.MATCH_ALL_PATTERN, serviceId = KubernetesHttpClientFactory.CLIENT_ID)
 final class KubernetesHttpClientFilter implements HttpClientFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(KubernetesHttpClientFilter.class);
 
     private final Provider<KubeConfig> kubeConfigProvider;
     private final Provider<Collection<KubernetesTokenLoader>> kubernetesTokenLoaders;
@@ -61,31 +66,24 @@ final class KubernetesHttpClientFilter implements HttpClientFilter {
 
     @Override
     public Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
-        setAuthHeader(request);
-        return chain.proceed(request);
-    }
-
-    private void setAuthHeader(MutableHttpRequest<?> request) {
         KubeConfig kubeConfig = kubeConfigProvider.get();
         if (kubeConfig != null && kubeConfig.getUser() != null) {
             AuthInfo user = kubeConfig.getUser();
             if (user.clientCertificateData() != null && user.clientKeyData() != null) {
-                return;
+                return chain.proceed(request);
             }
             if (StringUtils.isNotEmpty(user.username()) && StringUtils.isNotEmpty(user.password())) {
-                request.basicAuth(user.username(), user.password());
-                return;
+                return chain.proceed(request.basicAuth(user.username(), user.password()));
             }
         }
-        String token = null;
-        for (KubernetesTokenLoader kubernetesTokenLoader : kubernetesTokenLoaders.get()) {
-            token = kubernetesTokenLoader.getToken();
-            if (StringUtils.isNotEmpty(token)) {
-                break;
-            }
-        }
-        if (StringUtils.isNotEmpty(token)) {
-            request.bearerAuth(token);
-        }
+
+        Mono<String> token = Flux.fromIterable(kubernetesTokenLoaders.get())
+            .doOnNext(tokenLoader -> LOG.trace("Trying to load token, loader={}", tokenLoader.getClass().getName()))
+            .concatMap(KubernetesTokenLoader::getToken)
+            .doOnNext(tokenLoader -> LOG.trace("aaaa, loader={}", tokenLoader.getClass().getName()))
+            .next()
+            .doOnNext(tokenLoader -> LOG.trace("bbb, loader={}", tokenLoader.getClass().getName()));
+
+        return token.flatMapMany(t -> chain.proceed(request.bearerAuth(t)));
     }
 }

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
@@ -17,20 +17,22 @@ package io.micronaut.kubernetes.client.openapi;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ProviderUtils;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpRequest;
-import io.micronaut.http.annotation.ClientFilter;
-import io.micronaut.http.annotation.RequestFilter;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.filter.ClientFilterChain;
+import io.micronaut.http.filter.HttpClientFilter;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfig;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfigLoader;
 import io.micronaut.kubernetes.client.openapi.config.KubernetesClientConfiguration;
 import io.micronaut.kubernetes.client.openapi.config.model.AuthInfo;
 import io.micronaut.kubernetes.client.openapi.credential.KubernetesTokenLoader;
-import io.micronaut.scheduling.TaskExecutors;
-import io.micronaut.scheduling.annotation.ExecuteOn;
 import jakarta.inject.Provider;
+import org.reactivestreams.Publisher;
 
 import java.util.Collection;
 
@@ -38,10 +40,11 @@ import java.util.Collection;
  * Filter which sets the authorization request header with basic or bearer token
  * if the client certificate authentication is not enabled.
  */
-@ClientFilter(serviceId = KubernetesHttpClientFactory.CLIENT_ID)
 @Requires(beans = KubernetesClientConfiguration.class)
 @Internal
-final class KubernetesHttpClientFilter {
+@BootstrapContextCompatible
+@Filter(patterns = Filter.MATCH_ALL_PATTERN, serviceId = KubernetesHttpClientFactory.CLIENT_ID)
+final class KubernetesHttpClientFilter implements HttpClientFilter {
 
     private final Provider<KubeConfig> kubeConfigProvider;
     private final Provider<Collection<KubernetesTokenLoader>> kubernetesTokenLoaders;
@@ -56,9 +59,13 @@ final class KubernetesHttpClientFilter {
             () -> applicationContext.getBeansOfType(KubernetesTokenLoader.class));
     }
 
-    @RequestFilter
-    @ExecuteOn(TaskExecutors.BLOCKING)
-    void doFilter(MutableHttpRequest<?> request) {
+    @Override
+    public Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
+        setAuthHeader(request);
+        return chain.proceed(request);
+    }
+
+    private void setAuthHeader(MutableHttpRequest<?> request) {
         KubeConfig kubeConfig = kubeConfigProvider.get();
         if (kubeConfig != null && kubeConfig.getUser() != null) {
             AuthInfo user = kubeConfig.getUser();

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesHttpClientFilter.java
@@ -87,8 +87,6 @@ final class KubernetesHttpClientFilter implements HttpClientFilter {
             .doOnNext(token -> {
                 if (StringUtils.isEmpty(token)) {
                     LOG.trace("Token not loaded by any token loader");
-                } else {
-                    LOG.trace("Token loaded");
                 }
             })
             .flatMapMany(token -> StringUtils.isEmpty(token) ? chain.proceed(request) : chain.proceed(request.bearerAuth(token)));

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ExecCommandCredentialLoader.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ExecCommandCredentialLoader.java
@@ -17,15 +17,22 @@ package io.micronaut.kubernetes.client.openapi.credential;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfig;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfigLoader;
 import io.micronaut.kubernetes.client.openapi.config.model.ExecConfig;
 import io.micronaut.kubernetes.client.openapi.config.model.ExecEnvVar;
 import io.micronaut.kubernetes.client.openapi.credential.model.ExecCredential;
+import io.micronaut.scheduling.TaskExecutors;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.File;
 import java.io.InputStream;
@@ -37,6 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 /**
  * The credential loader which uses the exec command from the kube config to get credentials.
@@ -53,18 +61,16 @@ final class ExecCommandCredentialLoader implements KubernetesTokenLoader {
 
     private final KubeConfig kubeConfig;
     private final JsonMapper jsonMapper;
+    private final Scheduler scheduler;
 
     private volatile ExecCredential execCredential;
 
-    ExecCommandCredentialLoader(KubeConfigLoader kubeConfigLoader, JsonMapper jsonMapper) {
+    ExecCommandCredentialLoader(KubeConfigLoader kubeConfigLoader,
+                                JsonMapper jsonMapper,
+                                @Named(TaskExecutors.BLOCKING) @Nullable ExecutorService executorService) {
         kubeConfig = kubeConfigLoader.getKubeConfig();
         this.jsonMapper = jsonMapper;
-    }
-
-    @Override
-    public String getToken() {
-        setExecCredential();
-        return execCredential == null ? null : execCredential.status().token();
+        this.scheduler = executorService == null ? null : Schedulers.fromExecutorService(executorService);
     }
 
     @Override
@@ -72,10 +78,22 @@ final class ExecCommandCredentialLoader implements KubernetesTokenLoader {
         return ORDER;
     }
 
-    private void setExecCredential() {
+    @Override
+    public Publisher<String> getToken() {
         if (kubeConfig == null || !kubeConfig.isExecCommandProvided()) {
-            return;
+            return Mono.empty();
         }
+        if (!shouldLoadCredential()) {
+            return Mono.just(execCredential.status().token());
+        }
+        Mono<String> publisher = Mono.fromCallable(this::getTokenFromReloadedCredential);
+        if (scheduler != null) {
+            publisher = publisher.subscribeOn(scheduler);
+        }
+        return publisher;
+    }
+
+    private String getTokenFromReloadedCredential() {
         if (shouldLoadCredential()) {
             synchronized (this) {
                 if (shouldLoadCredential()) {
@@ -87,6 +105,7 @@ final class ExecCommandCredentialLoader implements KubernetesTokenLoader {
                 }
             }
         }
+        return execCredential == null ? null : execCredential.status().token();
     }
 
     private boolean shouldLoadCredential() {

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ExecCommandCredentialLoader.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ExecCommandCredentialLoader.java
@@ -85,13 +85,13 @@ final class ExecCommandCredentialLoader implements KubernetesTokenLoader {
         }
         if (!shouldLoadCredential()) {
             return Mono.just(execCredential.status().token())
-                .doOnNext(token -> LOG.trace("Token loaded by {}", this.getClass().getName()));
+                .doOnNext(token -> LOG.trace("Token loaded"));
         }
         Mono<String> publisher = Mono.fromCallable(this::getTokenFromReloadedCredential);
         if (scheduler != null) {
             publisher = publisher.subscribeOn(scheduler);
         }
-        return publisher.doOnNext(token -> LOG.trace("Token loaded by {}", this.getClass().getName()));
+        return publisher.doOnNext(token -> LOG.trace("Token loaded"));
     }
 
     private String getTokenFromReloadedCredential() {

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ExecCommandCredentialLoader.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ExecCommandCredentialLoader.java
@@ -84,13 +84,14 @@ final class ExecCommandCredentialLoader implements KubernetesTokenLoader {
             return Mono.empty();
         }
         if (!shouldLoadCredential()) {
-            return Mono.just(execCredential.status().token());
+            return Mono.just(execCredential.status().token())
+                .doOnNext(token -> LOG.trace("Token loaded by {}", this.getClass().getName()));
         }
         Mono<String> publisher = Mono.fromCallable(this::getTokenFromReloadedCredential);
         if (scheduler != null) {
             publisher = publisher.subscribeOn(scheduler);
         }
-        return publisher;
+        return publisher.doOnNext(token -> LOG.trace("Token loaded by {}", this.getClass().getName()));
     }
 
     private String getTokenFromReloadedCredential() {

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/KubeConfigTokenLoader.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/KubeConfigTokenLoader.java
@@ -53,6 +53,6 @@ final class KubeConfigTokenLoader implements KubernetesTokenLoader {
     public Publisher<String> getToken() {
         return StringUtils.isEmpty(token)
             ? Mono.empty()
-            : Mono.just(token).doOnNext(token -> LOG.trace("Token loaded by {}", this.getClass().getName()));
+            : Mono.just(token).doOnNext(token -> LOG.trace("Token loaded"));
     }
 }

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/KubeConfigTokenLoader.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/KubeConfigTokenLoader.java
@@ -17,9 +17,12 @@ package io.micronaut.kubernetes.client.openapi.credential;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfig;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfigLoader;
 import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
 
 /**
  * Loads a token from users settings in the kube config file.
@@ -39,12 +42,12 @@ final class KubeConfigTokenLoader implements KubernetesTokenLoader {
     }
 
     @Override
-    public String getToken() {
-        return token;
+    public int getOrder() {
+        return ORDER;
     }
 
     @Override
-    public int getOrder() {
-        return ORDER;
+    public Publisher<String> getToken() {
+        return StringUtils.isEmpty(token) ? Mono.empty() : Mono.just(token);
     }
 }

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/KubeConfigTokenLoader.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/KubeConfigTokenLoader.java
@@ -53,6 +53,6 @@ final class KubeConfigTokenLoader implements KubernetesTokenLoader {
     public Publisher<String> getToken() {
         return StringUtils.isEmpty(token)
             ? Mono.empty()
-            : Mono.just(token).doOnNext(token -> LOG.trace("Token loaded"));
+            : Mono.just(token).doOnNext(it -> LOG.trace("Token loaded"));
     }
 }

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/KubeConfigTokenLoader.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/KubeConfigTokenLoader.java
@@ -22,6 +22,8 @@ import io.micronaut.kubernetes.client.openapi.config.KubeConfig;
 import io.micronaut.kubernetes.client.openapi.config.KubeConfigLoader;
 import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 /**
@@ -31,6 +33,7 @@ import reactor.core.publisher.Mono;
 @BootstrapContextCompatible
 @Internal
 final class KubeConfigTokenLoader implements KubernetesTokenLoader {
+    private static final Logger LOG = LoggerFactory.getLogger(KubeConfigTokenLoader.class);
 
     private static final int ORDER = 20;
 
@@ -48,6 +51,8 @@ final class KubeConfigTokenLoader implements KubernetesTokenLoader {
 
     @Override
     public Publisher<String> getToken() {
-        return StringUtils.isEmpty(token) ? Mono.empty() : Mono.just(token);
+        return StringUtils.isEmpty(token)
+            ? Mono.empty()
+            : Mono.just(token).doOnNext(token -> LOG.trace("Token loaded by {}", this.getClass().getName()));
     }
 }

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/KubernetesTokenLoader.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/KubernetesTokenLoader.java
@@ -15,8 +15,9 @@
  */
 package io.micronaut.kubernetes.client.openapi.credential;
 
-import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.order.Ordered;
+import org.reactivestreams.Publisher;
 
 /**
  * The loader for bearer token used in kubernetes api service authentication.
@@ -28,5 +29,5 @@ public interface KubernetesTokenLoader extends Ordered {
      *
      * @return bearer token
      */
-    @Nullable String getToken();
+    @NonNull Publisher<String> getToken();
 }

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ServiceAccountTokenLoader.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ServiceAccountTokenLoader.java
@@ -78,13 +78,13 @@ final class ServiceAccountTokenLoader implements KubernetesTokenLoader {
     @Override
     public Publisher<String> getToken() {
         if (!shouldLoadToken()) {
-            return Mono.just(token).doOnNext(token -> LOG.trace("Token loaded"));
+            return Mono.just(token).doOnNext(it -> LOG.trace("Token loaded"));
         }
         Mono<String> publisher = Mono.fromCallable(this::reloadedToken);
         if (scheduler != null) {
             publisher = publisher.subscribeOn(scheduler);
         }
-        return publisher.doOnNext(token -> LOG.trace("Token loaded"));
+        return publisher.doOnNext(it -> LOG.trace("Token loaded"));
     }
 
     private String reloadedToken() {

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ServiceAccountTokenLoader.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ServiceAccountTokenLoader.java
@@ -17,28 +17,38 @@ package io.micronaut.kubernetes.client.openapi.credential;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.kubernetes.client.openapi.config.KubernetesClientConfiguration;
 import io.micronaut.kubernetes.client.openapi.config.KubernetesClientConfiguration.ServiceAccount;
+import io.micronaut.scheduling.TaskExecutors;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Loads a token from the service account token file.
  */
+@Internal
 @Singleton
 @BootstrapContextCompatible
-@Internal
+@Requires(env = Environment.KUBERNETES)
 @Requires(property = KubernetesClientConfiguration.PREFIX + ".service-account.enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
 final class ServiceAccountTokenLoader implements KubernetesTokenLoader {
     private static final Logger LOG = LoggerFactory.getLogger(ServiceAccountTokenLoader.class);
@@ -47,20 +57,17 @@ final class ServiceAccountTokenLoader implements KubernetesTokenLoader {
 
     private final ResourceResolver resourceResolver;
     private final ServiceAccount serviceAccount;
+    private final Scheduler scheduler;
 
     private volatile String token;
     private volatile LocalDateTime expirationTime;
 
     ServiceAccountTokenLoader(ResourceResolver resourceResolver,
-                              KubernetesClientConfiguration kubernetesClientConfiguration) {
+                              KubernetesClientConfiguration kubernetesClientConfiguration,
+                              @Named(TaskExecutors.BLOCKING) @Nullable ExecutorService executorService) {
         this.resourceResolver = resourceResolver;
         serviceAccount = kubernetesClientConfiguration.getServiceAccount();
-    }
-
-    @Override
-    public String getToken() {
-        setToken();
-        return token;
+        this.scheduler = executorService == null ? null : Schedulers.fromExecutorService(executorService);
     }
 
     @Override
@@ -68,7 +75,19 @@ final class ServiceAccountTokenLoader implements KubernetesTokenLoader {
         return ORDER;
     }
 
-    private void setToken() {
+    @Override
+    public Publisher<String> getToken() {
+        if (!shouldLoadToken()) {
+            return Mono.just(token);
+        }
+        Mono<String> publisher = Mono.fromCallable(this::getReloadedToken);
+        if (scheduler != null) {
+            publisher = publisher.subscribeOn(scheduler);
+        }
+        return publisher;
+    }
+
+    private String getReloadedToken() {
         if (shouldLoadToken()) {
             synchronized (this) {
                 if (shouldLoadToken()) {
@@ -76,13 +95,14 @@ final class ServiceAccountTokenLoader implements KubernetesTokenLoader {
                     Duration tokenReloadInterval = serviceAccount.getTokenReloadInterval();
                     try {
                         token = loadToken(tokenPath);
-                    } catch (IOException e) {
-                        throw new RuntimeException("Failed to load service account token from file: " + tokenPath, e);
+                        expirationTime = LocalDateTime.now().plusSeconds(tokenReloadInterval.toSeconds());
+                    } catch (Exception e) {
+                        LOG.error("Failed to load service account token from file: {}", tokenPath, e);
                     }
-                    expirationTime = LocalDateTime.now().plusSeconds(tokenReloadInterval.toSeconds());
                 }
             }
         }
+        return token;
     }
 
     private boolean shouldLoadToken() {

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ServiceAccountTokenLoader.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ServiceAccountTokenLoader.java
@@ -78,13 +78,13 @@ final class ServiceAccountTokenLoader implements KubernetesTokenLoader {
     @Override
     public Publisher<String> getToken() {
         if (!shouldLoadToken()) {
-            return Mono.just(token).doOnNext(token -> LOG.trace("Token loaded by {}", this.getClass().getName()));
+            return Mono.just(token).doOnNext(token -> LOG.trace("Token loaded"));
         }
         Mono<String> publisher = Mono.fromCallable(this::reloadedToken);
         if (scheduler != null) {
             publisher = publisher.subscribeOn(scheduler);
         }
-        return publisher.doOnNext(token -> LOG.trace("Token loaded by {}", this.getClass().getName()));
+        return publisher.doOnNext(token -> LOG.trace("Token loaded"));
     }
 
     private String reloadedToken() {
@@ -97,7 +97,7 @@ final class ServiceAccountTokenLoader implements KubernetesTokenLoader {
                         token = loadToken(tokenPath);
                         expirationTime = LocalDateTime.now().plusSeconds(tokenReloadInterval.toSeconds());
                     } catch (Exception e) {
-                        LOG.error("Failed to load service account token from file: {}", tokenPath, e);
+                        LOG.error("Failed to load token from file: {}", tokenPath, e);
                     }
                 }
             }

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ServiceAccountTokenLoader.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/credential/ServiceAccountTokenLoader.java
@@ -78,16 +78,16 @@ final class ServiceAccountTokenLoader implements KubernetesTokenLoader {
     @Override
     public Publisher<String> getToken() {
         if (!shouldLoadToken()) {
-            return Mono.just(token);
+            return Mono.just(token).doOnNext(token -> LOG.trace("Token loaded by {}", this.getClass().getName()));
         }
-        Mono<String> publisher = Mono.fromCallable(this::getReloadedToken);
+        Mono<String> publisher = Mono.fromCallable(this::reloadedToken);
         if (scheduler != null) {
             publisher = publisher.subscribeOn(scheduler);
         }
-        return publisher;
+        return publisher.doOnNext(token -> LOG.trace("Token loaded by {}", this.getClass().getName()));
     }
 
-    private String getReloadedToken() {
+    private String reloadedToken() {
         if (shouldLoadToken()) {
             synchronized (this) {
                 if (shouldLoadToken()) {

--- a/kubernetes-client-openapi-common/src/test/groovy/io/micronaut/kubernetes/client/openapi/credential/ServiceAccountTokenLoaderSpec.groovy
+++ b/kubernetes-client-openapi-common/src/test/groovy/io/micronaut/kubernetes/client/openapi/credential/ServiceAccountTokenLoaderSpec.groovy
@@ -1,6 +1,8 @@
 package io.micronaut.kubernetes.client.openapi.credential
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import reactor.core.publisher.Mono
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Stepwise
@@ -21,7 +23,7 @@ class ServiceAccountTokenLoaderSpec extends Specification {
     ApplicationContext clientContext = ApplicationContext.run([
             'kubernetes.client.service-account.token-path': "file:" + tokenFile,
             'kubernetes.client.service-account.token-reload-interval': '1s'
-    ])
+    ], Environment.KUBERNETES)
 
     @Shared
     def tokenLoader = clientContext.getBean(ServiceAccountTokenLoader.class)
@@ -40,7 +42,7 @@ class ServiceAccountTokenLoaderSpec extends Specification {
         tokenFile.toFile().text = 'old-test-token'
 
         when:
-        def token = tokenLoader.getToken()
+        def token = Mono.from(tokenLoader.getToken()).block()
 
         then:
         token == 'old-test-token'
@@ -51,7 +53,7 @@ class ServiceAccountTokenLoaderSpec extends Specification {
         tokenFile.toFile().text = 'new-test-token'
 
         when:
-        def token = tokenLoader.getToken()
+        def token = Mono.from(tokenLoader.getToken()).block()
 
         then:
         token == 'old-test-token'
@@ -62,7 +64,7 @@ class ServiceAccountTokenLoaderSpec extends Specification {
         sleep(1000)
 
         when:
-        def token = tokenLoader.getToken()
+        def token = Mono.from(tokenLoader.getToken()).block()
 
         then:
         token == 'new-test-token'

--- a/kubernetes-client-openapi-discovery/src/main/java/io/micronaut/kubernetes/client/openapi/discovery/provider/KubernetesServiceInstanceEndpointProvider.java
+++ b/kubernetes-client-openapi-discovery/src/main/java/io/micronaut/kubernetes/client/openapi/discovery/provider/KubernetesServiceInstanceEndpointProvider.java
@@ -47,14 +47,14 @@ final class KubernetesServiceInstanceEndpointProvider extends AbstractV1Endpoint
 
     @Override
     public Mono<V1Endpoints> getEndpoints(String name, String namespace) {
-        LOG.trace("Using API to fetch Endpoints [{}] from namespace [{}]", name, namespace);
+        LOG.trace("Using API to fetch [{}] Endpoints from namespace [{}]", name, namespace);
         return client.readNamespacedEndpoints(name, namespace, null)
                 .doOnError(throwable -> LOG.error("Failed to list Endpoints [{}] from namespace [{}]", name, namespace, throwable));
     }
 
     @Override
     public Flux<V1Endpoints> listEndpoints(String namespace) {
-        LOG.trace("Using API to fetch endpoints from namespace [{}]", namespace);
+        LOG.trace("Using API to fetch all endpoints from namespace [{}]", namespace);
 
         return client.listNamespacedEndpoints(namespace, null, null, null, null, null, null, null, null, null, null, null)
                 .doOnError(throwable -> LOG.error("Failed to list Endpoints from namespace [{}]", namespace, throwable))

--- a/kubernetes-client-openapi-discovery/src/main/java/io/micronaut/kubernetes/client/openapi/discovery/provider/KubernetesServiceInstanceServiceProvider.java
+++ b/kubernetes-client-openapi-discovery/src/main/java/io/micronaut/kubernetes/client/openapi/discovery/provider/KubernetesServiceInstanceServiceProvider.java
@@ -47,14 +47,14 @@ final class KubernetesServiceInstanceServiceProvider extends AbstractV1ServicePr
 
     @Override
     public Mono<V1Service> getService(String name, String namespace) {
-        LOG.trace("Using API to fetch Service [{}] from namespace [{}]", name, namespace);
+        LOG.trace("Using API to fetch [{}] Service from namespace [{}]", name, namespace);
         return client.readNamespacedService(name, namespace, null)
                 .doOnError(throwable -> LOG.error("Failed to fetch Service [{}] from namespace [{}]", name, namespace, throwable));
     }
 
     @Override
     public Flux<V1Service> listServices(String namespace) {
-        LOG.trace("Using API to fetch services from namespace [{}]", namespace);
+        LOG.trace("Using API to fetch all services from namespace [{}]", namespace);
         return client.listNamespacedService(namespace, null, null, null, null, null, null, null, null, null, null, null)
                 .doOnError(throwable -> LOG.error("Failed to list Services from namespace [{}]", namespace, throwable))
                 .flatMapIterable(V1ServiceList::getItems);

--- a/kubernetes-client-openapi/build.gradle
+++ b/kubernetes-client-openapi/build.gradle
@@ -34,4 +34,5 @@ dependencies {
     testImplementation(libs.testcontainers.k3s)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.http.client)
+    testImplementation(mnReactor.micronaut.reactor)
 }

--- a/kubernetes-client-openapi/src/test/groovy/io/micronaut/kubernetes/client/openapi/ClientCredentialLoaderSpec.groovy
+++ b/kubernetes-client-openapi/src/test/groovy/io/micronaut/kubernetes/client/openapi/ClientCredentialLoaderSpec.groovy
@@ -12,6 +12,8 @@ import io.micronaut.kubernetes.client.openapi.model.V1Pod
 import io.micronaut.kubernetes.client.openapi.model.V1PodList
 import io.micronaut.runtime.server.EmbeddedServer
 import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -97,8 +99,8 @@ current-context: test-context
     static class FirstCredentialLoader implements KubernetesTokenLoader {
 
         @Override
-        String getToken() {
-            return "first"
+        Publisher<String> getToken() {
+            return Mono.just("first")
         }
 
         @Override
@@ -113,8 +115,8 @@ current-context: test-context
     static class SecondCredentialLoader implements KubernetesTokenLoader {
 
         @Override
-        String getToken() {
-            return "second"
+        Publisher<String> getToken() {
+            return Mono.just("second")
         }
 
         @Override


### PR DESCRIPTION
Changes:
- modified `KubernetesHttpClientFilter` to use `HttpClientFilter` interface instead of `@ClientFilter` annotation so it can be applied in the bootstrap context too
- modified `KubernetesTokenLoader` interface (breaking change) so its implementation can decided whether they need to be executed on the `nio event loop` or `blocking` thread pool