### PR TITLE
"Fix the order of arguments, which causes the resourceGroup and plural to be switched in SharedIndexInformerFactory.sharedIndexInformerFor

### DIFF
--- a/kubernetes-informer/src/main/java/io/micronaut/kubernetes/client/informer/SharedIndexInformerFactory.java
+++ b/kubernetes-informer/src/main/java/io/micronaut/kubernetes/client/informer/SharedIndexInformerFactory.java
@@ -48,8 +48,8 @@ public interface SharedIndexInformerFactory {
     <ApiType extends KubernetesObject, ApiListType extends KubernetesListObject> SharedIndexInformer<ApiType> sharedIndexInformerFor(
             Class<ApiType> apiTypeClass,
             Class<ApiListType> apiListTypeClass,
-            String apiGroup,
             String resourcePlural,
+            String apiGroup,
             @Nullable String namespace,
             @Nullable String labelSelector,
             @Nullable Long resyncCheckPeriod,


### PR DESCRIPTION
 Fix the order of arguments, which causes the resourceGroup and plural to be switched in SharedIndexInformerFactory.sharedIndexInformerFor