### PR TITLE
Modified response of delete methods in Kubernetes Client OpenAPI blocking and reactive client

### DIFF
--- a/build-logic/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesClientOpenApiPlugin.java
+++ b/build-logic/src/main/java/io/micronaut/kubernetes/client/openapi/KubernetesClientOpenApiPlugin.java
@@ -17,6 +17,7 @@ package io.micronaut.kubernetes.client.openapi;
 
 import io.micronaut.kubernetes.client.openapi.tasks.CreateWatcherSpec;
 import io.micronaut.kubernetes.client.openapi.tasks.DownloadSpec;
+import io.micronaut.kubernetes.client.openapi.tasks.ModifySpec;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskProvider;
@@ -28,7 +29,9 @@ public class KubernetesClientOpenApiPlugin implements Plugin<Project> {
 
     private static final String OPENAPI_SPEC_FILE_NAME = "openapi.yaml";
     private static final String OPENAPI_WATCHER_SPEC_FILE_NAME = "openapi-watcher.yaml";
+    private static final String OPENAPI_MODIFIED_SPEC_FILE_NAME = "openapi-modified.yaml";
     private static final String OPENAPI_WATCHER_TYPE_MAPPINGS_FILE_NAME = "openapi-watcher-type-mappings.txt";
+    private static final String OPENAPI_DELETE_RESPONSE_MAPPINGS_FILE_NAME = "openapi-delete-response-mappings.txt";
 
     @Override
     public void apply(Project project) {
@@ -48,6 +51,13 @@ public class KubernetesClientOpenApiPlugin implements Plugin<Project> {
             task.getModelPackageName().set(kubernetesClientOpenApiExtension.getModelPackageName());
             task.getWatcherSpecFile().convention(project.getLayout().getBuildDirectory().file(OPENAPI_WATCHER_SPEC_FILE_NAME));
             task.getWatcherTypeMappingsFile().convention(project.getLayout().getBuildDirectory().file(OPENAPI_WATCHER_TYPE_MAPPINGS_FILE_NAME));
+        });
+        project.getTasks().register("modifyOpenApiSpec", ModifySpec.class, task -> {
+            task.setGroup("kubernetes client openapi");
+            task.setDescription("Creates a new spec from the downloaded client openapi spec");
+            task.getInputSpecFile().convention(downloadSpecTask.flatMap(DownloadSpec::getSpecFile));
+            task.getModifiedSpecFile().convention(project.getLayout().getBuildDirectory().file(OPENAPI_MODIFIED_SPEC_FILE_NAME));
+            task.getDeleteResponseMappingsFile().convention(project.getLayout().getBuildDirectory().file(OPENAPI_DELETE_RESPONSE_MAPPINGS_FILE_NAME));
         });
     }
 }

--- a/build-logic/src/main/java/io/micronaut/kubernetes/client/openapi/tasks/CreateWatcherSpec.java
+++ b/build-logic/src/main/java/io/micronaut/kubernetes/client/openapi/tasks/CreateWatcherSpec.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.kubernetes.client.openapi.tasks;
 
 import org.gradle.api.DefaultTask;
@@ -7,15 +22,10 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.SafeConstructor;
-import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.File;
 import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -46,6 +56,7 @@ import java.util.stream.Collectors;
  * </pre>
  * </p>
  */
+@SuppressWarnings("unchecked")
 public abstract class CreateWatcherSpec extends DefaultTask {
 
     @InputFile
@@ -67,7 +78,7 @@ public abstract class CreateWatcherSpec extends DefaultTask {
         Map<String, Object> watcherSpecMap = new LinkedHashMap<>();
         Map<String, String> watcherTypeMappings = new LinkedHashMap<>();
 
-        Yaml yaml = createYaml();
+        Yaml yaml = TaskUtils.createYaml();
 
         FileReader fileReader = new FileReader(getInputSpecFile().getAsFile().get());
         Map<String, Object> inputSpecMap = yaml.load(fileReader);
@@ -81,8 +92,13 @@ public abstract class CreateWatcherSpec extends DefaultTask {
             }
         });
 
-        createWatcherSpecFile(yaml, watcherSpecMap);
-        createWatcherTypeMappingsFile(watcherTypeMappings);
+        File specFile = getWatcherSpecFile().getAsFile().get();
+        TaskUtils.createSpecFile(yaml, watcherSpecMap, specFile);
+        getLogger().info("Created kubernetes client watcher openapi spec file: {}", specFile.getAbsolutePath());
+
+        File typeMappingsFile = getWatcherTypeMappingsFile().getAsFile().get();
+        TaskUtils.createTypeMappingsFile(watcherTypeMappings, typeMappingsFile);
+        getLogger().info("Created kubernetes client watcher openapi type mappings file: {}", typeMappingsFile.getAbsolutePath());
     }
 
     private Map<String, Object> processPaths(Map<String, Object> paths, Map<String, String> watcherTypeMappings) {
@@ -150,34 +166,5 @@ public abstract class CreateWatcherSpec extends DefaultTask {
 
     private Map<String, Object> getMapValue(Map<String, Object> map, String key) {
         return (Map<String, Object>) map.get(key);
-    }
-
-    private Yaml createYaml() {
-        LoaderOptions loaderOptions = new LoaderOptions();
-        loaderOptions.setCodePointLimit(15728640);
-        DumperOptions dumperOptions = new DumperOptions();
-        dumperOptions.setPrettyFlow(true);
-        dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-        return new Yaml(new SafeConstructor(loaderOptions), new Representer(dumperOptions));
-    }
-
-    private void createWatcherSpecFile(Yaml yaml, Map<String, Object> watcherSpecMap) throws IOException {
-        File file = getWatcherSpecFile().getAsFile().get();
-        try (FileWriter fileWriter = new FileWriter(file)) {
-            yaml.dump(watcherSpecMap, fileWriter);
-        }
-        getLogger().info("Created kubernetes client watcher openapi spec file: {}", file.getAbsolutePath());
-    }
-
-    private void createWatcherTypeMappingsFile(Map<String, String> typeMappings) throws IOException {
-        File file = getWatcherTypeMappingsFile().getAsFile().get();
-        String typeMappingsStr = typeMappings.entrySet()
-            .stream()
-            .map(entry -> "\"" + entry.getKey() + "\": \"" + entry.getValue() + "\"")
-            .collect(Collectors.joining(", "));
-        try (FileWriter fileWriter = new FileWriter(file)) {
-            fileWriter.write("[" + typeMappingsStr + "]");
-        }
-        getLogger().info("Created kubernetes client watcher openapi type mappings file: {}", file.getAbsolutePath());
     }
 }

--- a/build-logic/src/main/java/io/micronaut/kubernetes/client/openapi/tasks/ModifySpec.java
+++ b/build-logic/src/main/java/io/micronaut/kubernetes/client/openapi/tasks/ModifySpec.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kubernetes.client.openapi.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * <p>The task creates a new openapi spec from the already downloaded spec.</p>
+ * <br />
+ * <p>The main difference between the downloaded spec and the new spec is in response schemas for
+ * delete resource operations. In the downloaded spec, response schemas are {@code v1.Status} or
+ * schema of object which is being deleted (for example, {@code v1.ConfigMap}). In the new spec,
+ * those schemas are replaced with placeholder schemas (for example, {@code v1.ConfigMapPlaceholder}).
+ * The placeholder schemas are mapped to generic types in {@code openapi-delete-response-mappings.txt}
+ * file (for example, {@code v1.ConfigMapPlaceholder} is mapped to {@code DeleteResponse<V1ConfigMap>}).
+ * When the open api generator is executed, the placeholders are replaced with mapped values from
+ * the mapping file.
+ * </p>
+ * <br />
+ * <p>
+ * Usage of {@code DeleteResponse} class solves the issue caused by receiving different jsons
+ * ({@code V1Status} vs. resource being deleted) from the kubernetes api server based on the server
+ * configuration for each resource.
+ * </p>
+ * @see <a href="https://github.com/kubernetes/kubernetes/issues/59501#issuecomment-370013330">Delete Resource Issue</a>
+ */
+@SuppressWarnings("unchecked")
+public abstract class ModifySpec extends DefaultTask {
+
+    @InputFile
+    public abstract RegularFileProperty getInputSpecFile();
+
+    @OutputFile
+    public abstract RegularFileProperty getModifiedSpecFile();
+
+    @OutputFile
+    public abstract RegularFileProperty getDeleteResponseMappingsFile();
+
+    @TaskAction
+    void modifySpecFile() throws IOException {
+        getLogger().info("Modifying openapi spec file");
+
+        Map<String, String> deleteResponseMappings = new LinkedHashMap<>();
+
+        Yaml yaml = TaskUtils.createYaml();
+
+        FileReader fileReader = new FileReader(getInputSpecFile().getAsFile().get());
+        Map<String, Object> inputSpecMap = yaml.load(fileReader);
+
+        inputSpecMap.forEach((specKey, specValue) -> {
+            if ("paths".equals(specKey)) {
+                processPaths((Map<String, Object>) specValue, deleteResponseMappings);
+            }
+        });
+
+        File specFile = getModifiedSpecFile().getAsFile().get();
+        TaskUtils.createSpecFile(yaml, inputSpecMap, specFile);
+        getLogger().info("Created kubernetes client modified spec file: {}", specFile.getAbsolutePath());
+
+        File typeMappingsFile = getDeleteResponseMappingsFile().getAsFile().get();
+        TaskUtils.createTypeMappingsFile(deleteResponseMappings, typeMappingsFile);
+        getLogger().info("Created kubernetes client delete response mappings file: {}", typeMappingsFile.getAbsolutePath());
+    }
+
+    private void processPaths(Map<String, Object> paths, Map<String, String> deleteResponseMappings) {
+        for (Object pathData : paths.values()) {
+            Map<String, Object> operations = (Map<String, Object>) pathData;
+            Map<String, Object> deleteOpData = getMapValue(operations, "delete");
+            Map<String, Object> getOpData = getMapValue(operations, "get");
+            if (deleteOpData != null && getOpData != null) {
+                String deleteObjectSchemaRef = getSchemaRef(getOpData);
+                if (deleteObjectSchemaRef != null) {
+                    String placeholderSchemaRef = deleteObjectSchemaRef + "Placeholder";
+                    if (modifyResponseData(deleteOpData, placeholderSchemaRef)) {
+                        addMapping(deleteObjectSchemaRef, placeholderSchemaRef, deleteResponseMappings);
+                    }
+                }
+            }
+        }
+    }
+
+    private String getSchemaRef(Map<String, Object> operationData) {
+        boolean nameParamFound = false;
+        List<Map<String, Object>> parameters = (List<Map<String, Object>>) operationData.get("parameters");
+        if (parameters != null) {
+            for (Map<String, Object> parameterMap : parameters) {
+                if (parameterMap.get("name").equals("name")) {
+                    nameParamFound = true;
+                    break;
+                }
+            }
+        }
+        if (!nameParamFound) {
+            return null;
+        }
+        Map<String, Object> responses = getMapValue(operationData, "responses");
+        Map<String, Object> responseData = getMapValue(responses, "200");
+        Map<String, Object> contents = getMapValue(responseData, "content");
+        if (contents != null) {
+            for (Object contentValue : contents.values()) {
+                Map<String, Object> contentValueData = (Map<String, Object>) contentValue;
+                Map<String, Object> schemaData = getMapValue(contentValueData, "schema");
+                String schemaRef = schemaData == null ? null : (String) schemaData.get("$ref");
+                if (schemaRef != null) {
+                    return schemaRef;
+                }
+            }
+        }
+        return null;
+    }
+
+    private boolean modifyResponseData(Map<String, Object> operationData, String placeholderSchemaRef) {
+        boolean responseDataModified = false;
+        Map<String, Object> responses = getMapValue(operationData, "responses");
+        for (Object responseData: responses.values()) {
+            Map<String, Object> contents = getMapValue((Map<String, Object>) responseData, "content");
+            for (Object contentData: contents.values()) {
+                Map<String, Object> schemaData = getMapValue((Map<String, Object>) contentData, "schema");
+                String schemaRef = (String) schemaData.get("$ref");
+                if (schemaRef != null) {
+                    schemaData.put("$ref", placeholderSchemaRef);
+                    responseDataModified = true;
+                }
+            }
+        }
+        return responseDataModified;
+    }
+
+    private void addMapping(String deleteObjectSchemaRef, String placeholderSchemaRef, Map<String, String> deleteResponseMappings) {
+        String deleteObjectSchemaType = deleteObjectSchemaRef.substring("#/components/schemas/".length());
+        String deleteObjectSimpleName = Arrays.stream(deleteObjectSchemaType.split("\\."))
+            .map(word -> Character.toUpperCase(word.charAt(0)) + word.substring(1))
+            .collect(Collectors.joining(""));
+
+        String placeholderSchemaType = placeholderSchemaRef.substring("#/components/schemas/".length());
+        deleteResponseMappings.put(placeholderSchemaType, "io.micronaut.kubernetes.client.openapi.response.DeleteResponse<" + deleteObjectSimpleName + ">");
+    }
+
+    private Map<String, Object> getMapValue(Map<String, Object> map, String key) {
+        return map == null ? null : (Map<String, Object>) map.get(key);
+    }
+}

--- a/build-logic/src/main/java/io/micronaut/kubernetes/client/openapi/tasks/TaskUtils.java
+++ b/build-logic/src/main/java/io/micronaut/kubernetes/client/openapi/tasks/TaskUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kubernetes.client.openapi.tasks;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for openapi tasks.
+ */
+public class TaskUtils {
+
+    private static final int CODE_POINT_LIMIT = 15728640;
+
+    /**
+     * Creates and configures yaml.
+     *
+     * @return a {@link Yaml} instance
+     */
+    static Yaml createYaml() {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(CODE_POINT_LIMIT);
+        DumperOptions dumperOptions = new DumperOptions();
+        dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        return new Yaml(new SafeConstructor(loaderOptions), new Representer(dumperOptions), dumperOptions);
+    }
+
+    /**
+     * Creates a new spec file from given content.
+     *
+     * @param yaml    the yaml
+     * @param content the content
+     * @param file    the new file
+     * @throws IOException exception thrown when a new file cannot be created
+     */
+    static void createSpecFile(Yaml yaml, Map<String, Object> content, File file) throws IOException {
+        try (FileWriter fileWriter = new FileWriter(file)) {
+            yaml.dump(content, fileWriter);
+        }
+    }
+
+    /**
+     * Creates a new type mappings file.
+     *
+     * @param typeMappings the type mappings
+     * @param file         the new file
+     * @throws IOException exception thrown when a new file cannot be created
+     */
+    static void createTypeMappingsFile(Map<String, String> typeMappings, File file) throws IOException {
+        String typeMappingsStr = typeMappings.entrySet()
+            .stream()
+            .map(entry -> "\"" + entry.getKey() + "\": \"" + entry.getValue() + "\"")
+            .collect(Collectors.joining(", "));
+        try (FileWriter fileWriter = new FileWriter(file)) {
+            fileWriter.write("[" + typeMappingsStr + "]");
+        }
+    }
+}

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/response/DeleteResponse.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/response/DeleteResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kubernetes.client.openapi.response;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.kubernetes.client.openapi.model.V1Status;
+import io.micronaut.serde.annotation.Serdeable;
+
+/**
+ * Response which is used by kubernetes client delete methods can contain {@link V1Status} instance
+ * or an instance of the kubernetes object which is being deleted depending on kubernetes api server configuration.
+ *
+ * @param <T> the object type
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind", defaultImpl = ResourceDeleteResponse.class, visible = true)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = StatusDeleteResponse.class, name = "Status")
+})
+@Serdeable
+public sealed interface DeleteResponse<T> permits StatusDeleteResponse, ResourceDeleteResponse {
+    @Nullable
+    T object();
+
+    @Nullable
+    V1Status status();
+}

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/response/ResourceDeleteResponse.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/response/ResourceDeleteResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kubernetes.client.openapi.response;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.micronaut.kubernetes.client.openapi.model.V1Status;
+import io.micronaut.serde.annotation.Serdeable;
+
+/**
+ * Implementation of {@link DeleteResponse} interface which contains an instance of deleted kubernetes object.
+ *
+ * @param object the deleted kubernetes object
+ * @param <T>    the object type
+ */
+@Serdeable
+public record ResourceDeleteResponse<T>(
+    @JsonUnwrapped
+    T object
+) implements DeleteResponse<T> {
+    @Override
+    public V1Status status() {
+        return null;
+    }
+}

--- a/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/response/StatusDeleteResponse.java
+++ b/kubernetes-client-openapi-common/src/main/java/io/micronaut/kubernetes/client/openapi/response/StatusDeleteResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kubernetes.client.openapi.response;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.micronaut.kubernetes.client.openapi.model.V1Status;
+import io.micronaut.serde.annotation.Serdeable;
+
+/**
+ * Implementation of {@link DeleteResponse} interface which contains an instance of {@link V1Status}.
+ *
+ * @param status the instance of {@link V1Status}
+ * @param <T>    the object type
+ */
+@Serdeable
+public record StatusDeleteResponse<T>(
+    @JsonUnwrapped
+    V1Status status
+) implements DeleteResponse<T> {
+    @Override
+    public T object() {
+        return null;
+    }
+}

--- a/kubernetes-client-openapi-reactor/build.gradle
+++ b/kubernetes-client-openapi-reactor/build.gradle
@@ -1,4 +1,4 @@
-import io.micronaut.kubernetes.client.openapi.tasks.DownloadSpec
+import io.micronaut.kubernetes.client.openapi.tasks.ModifySpec
 
 plugins {
     id 'io.micronaut.build.internal.kubernetes-module'
@@ -13,13 +13,16 @@ kubernetesClientOpenApi {
 micronaut {
     openapi {
         version = libs.versions.micronaut.openapi.get()
-        client("client", tasks.named("downloadOpenApiSpec", DownloadSpec).flatMap(DownloadSpec::getSpecFile)) {
+        client("client", tasks.named("modifyOpenApiSpec", ModifySpec).flatMap(ModifySpec::getModifiedSpecFile)) {
             apiPackageName = "io.micronaut.kubernetes.client.openapi.reactor.api"
             modelPackageName = "io.micronaut.kubernetes.client.openapi.model"
             apiNameSuffix = "ApiReactor"
             clientId = "kubernetes"
             useReactive = true
             generateHttpResponseWhereRequired = false
+            typeMapping = tasks.named("modifyOpenApiSpec", ModifySpec).flatMap(ModifySpec::getDeleteResponseMappingsFile).map { t->
+                return evaluate(t.getAsFile())
+            }
             additionalClientTypeAnnotations = [
                     "@io.micronaut.kubernetes.client.openapi.reactor.annotation.KubernetesClientApiReactor",
                     "@io.micronaut.context.annotation.BootstrapContextCompatible"

--- a/kubernetes-client-openapi-reactor/src/test/groovy/io/micronaut/kubernetes/client/openapi/reactor/DeleteObjectSpec.groovy
+++ b/kubernetes-client-openapi-reactor/src/test/groovy/io/micronaut/kubernetes/client/openapi/reactor/DeleteObjectSpec.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.kubernetes.client.openapi.reactor
+
+import io.micronaut.kubernetes.client.openapi.model.V1ConfigMap
+import io.micronaut.kubernetes.client.openapi.model.V1Namespace
+import io.micronaut.kubernetes.client.openapi.model.V1ObjectMeta
+import io.micronaut.kubernetes.client.openapi.reactor.api.CoreV1ApiReactor
+import io.micronaut.kubernetes.client.openapi.response.DeleteResponse
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.k3s.K3sContainer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+@MicronautTest
+class DeleteObjectSpec extends Specification implements TestPropertyProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeleteObjectSpec)
+
+    @Shared
+    @AutoCleanup
+    K3sContainer k3s = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.31.5-k3s1"))
+            .withLogConsumer(new Slf4jLogConsumer(logger))
+
+    @Shared
+    Path kubeConfigDir = Files.createTempDirectory("kube-temp-")
+
+    @Shared
+    Path kubeConfigFile = kubeConfigDir.resolve("config")
+
+    @Inject
+    CoreV1ApiReactor api
+
+    @Override
+    Map<String, String> getProperties() {
+        k3s.start()
+        kubeConfigFile.toFile().text = k3s.getKubeConfigYaml()
+        ["kubernetes.client.kube-config-path": "file:" + kubeConfigFile.toString()]
+    }
+
+    def cleanupSpec() {
+        if (kubeConfigFile != null) {
+            Files.deleteIfExists(kubeConfigFile)
+        }
+        if (kubeConfigDir) {
+            Files.deleteIfExists(kubeConfigDir)
+        }
+    }
+
+    def 'delete kubernetes objects'() {
+        given:
+        V1Namespace namespace = new V1Namespace()
+        namespace.kind('Namespace')
+        namespace.apiVersion('v1')
+        V1ObjectMeta namespaceMetadata = new V1ObjectMeta()
+        namespaceMetadata.name('micronaut-test-namespace')
+        namespace.metadata(namespaceMetadata)
+        api.createNamespace(namespace, null, null, null, null).block()
+
+        V1ConfigMap configMap = new V1ConfigMap()
+        configMap.kind('ConfigMap')
+        configMap.apiVersion('v1')
+        configMap.data(['test.properties': 'testKey=testValue'])
+        V1ObjectMeta configMapMetadata = new V1ObjectMeta()
+        configMapMetadata.name('micronaut-test-config-map')
+        configMap.metadata(configMapMetadata)
+        api.createNamespacedConfigMap('micronaut-test-namespace', configMap, null, null, null, null).block()
+
+        when:
+        DeleteResponse<V1ConfigMap> configMapResponse = api.deleteNamespacedConfigMap('micronaut-test-config-map', 'micronaut-test-namespace', null, null, null, null, null, null).block()
+        DeleteResponse<V1Namespace> namespaceResponse = api.deleteNamespace('micronaut-test-namespace', null, null, null, null, null, null).block()
+
+        then:
+        configMapResponse.object() == null
+        configMapResponse.status().apiVersion == 'v1'
+        configMapResponse.status().details.kind == 'configmaps'
+        configMapResponse.status().details.name == 'micronaut-test-config-map'
+
+        namespaceResponse.object().apiVersion == 'v1'
+        namespaceResponse.object().metadata.name == 'micronaut-test-namespace'
+        namespaceResponse.status() == null
+    }
+}

--- a/kubernetes-client-openapi-reactor/src/test/groovy/io/micronaut/kubernetes/client/openapi/reactor/DeleteObjectSpec.groovy
+++ b/kubernetes-client-openapi-reactor/src/test/groovy/io/micronaut/kubernetes/client/openapi/reactor/DeleteObjectSpec.groovy
@@ -75,8 +75,8 @@ class DeleteObjectSpec extends Specification implements TestPropertyProvider {
         api.createNamespacedConfigMap('micronaut-test-namespace', configMap, null, null, null, null).block()
 
         when:
-        DeleteResponse<V1ConfigMap> configMapResponse = api.deleteNamespacedConfigMap('micronaut-test-config-map', 'micronaut-test-namespace', null, null, null, null, null, null).block()
-        DeleteResponse<V1Namespace> namespaceResponse = api.deleteNamespace('micronaut-test-namespace', null, null, null, null, null, null).block()
+        DeleteResponse<V1ConfigMap> configMapResponse = api.deleteNamespacedConfigMap('micronaut-test-config-map', 'micronaut-test-namespace', null, null, null, null, null, null, null).block()
+        DeleteResponse<V1Namespace> namespaceResponse = api.deleteNamespace('micronaut-test-namespace', null, null, null, null, null, null, null).block()
 
         then:
         configMapResponse.object() == null

--- a/kubernetes-client-openapi-watcher/src/test/groovy/io/micronaut/kubernetes/client/openapi/watcher/WatchEventsSpec.groovy
+++ b/kubernetes-client-openapi-watcher/src/test/groovy/io/micronaut/kubernetes/client/openapi/watcher/WatchEventsSpec.groovy
@@ -4,7 +4,7 @@ import io.micronaut.kubernetes.client.openapi.api.CoreV1Api
 import io.micronaut.kubernetes.client.openapi.model.V1Namespace
 import io.micronaut.kubernetes.client.openapi.model.V1ObjectMeta
 import io.micronaut.kubernetes.client.openapi.model.V1Secret
-import io.micronaut.kubernetes.client.openapi.model.V1Status
+import io.micronaut.kubernetes.client.openapi.response.DeleteResponse
 import io.micronaut.kubernetes.client.openapi.watcher.api.CoreV1ApiWatcher
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
@@ -77,7 +77,7 @@ class WatchEventsSpec extends Specification implements TestPropertyProvider {
         Disposable disposable = flux.subscribe(event -> {events.computeIfAbsent(event.object.metadata.name, key -> []).add(event.type)})
 
         replaceSecret(namespaceName, secretName)
-        V1Status v1Status = deleteSecret(namespaceName, secretName)
+        DeleteResponse<V1Secret> deleteResponse = deleteSecret(namespaceName, secretName)
 
         PollingConditions conditions = new PollingConditions(timeout: 2)
 
@@ -88,7 +88,7 @@ class WatchEventsSpec extends Specification implements TestPropertyProvider {
             events.get(secretName)?.get(1) == 'MODIFIED'
             events.get(secretName)?.get(2) == 'DELETED'
         }
-        v1Status.status == "Success"
+        deleteResponse.status().status == "Success"
 
         cleanup:
         disposable?.dispose()
@@ -126,7 +126,7 @@ class WatchEventsSpec extends Specification implements TestPropertyProvider {
         api.replaceNamespacedSecret(secretName, namespaceName, secret, null, null, null, null)
     }
 
-    private V1Status deleteSecret(String namespaceName, String secretName) {
+    private DeleteResponse<V1Secret> deleteSecret(String namespaceName, String secretName) {
         api.deleteNamespacedSecret(secretName, namespaceName, null, null, null, null, null, null, null)
     }
 }

--- a/kubernetes-client-openapi/build.gradle
+++ b/kubernetes-client-openapi/build.gradle
@@ -1,4 +1,4 @@
-import io.micronaut.kubernetes.client.openapi.tasks.DownloadSpec
+import io.micronaut.kubernetes.client.openapi.tasks.ModifySpec
 
 plugins {
     id 'io.micronaut.build.internal.kubernetes-module'
@@ -13,12 +13,15 @@ kubernetesClientOpenApi {
 micronaut {
     openapi {
         version = libs.versions.micronaut.openapi.get()
-        client("client", tasks.named("downloadOpenApiSpec", DownloadSpec).flatMap(DownloadSpec::getSpecFile)) {
+        client("client", tasks.named("modifyOpenApiSpec", ModifySpec).flatMap(ModifySpec::getModifiedSpecFile)) {
             apiPackageName = "io.micronaut.kubernetes.client.openapi.api"
             modelPackageName = "io.micronaut.kubernetes.client.openapi.model"
             clientId = "kubernetes"
             useReactive = false
             generateHttpResponseWhereRequired = false
+            typeMapping = tasks.named("modifyOpenApiSpec", ModifySpec).flatMap(ModifySpec::getDeleteResponseMappingsFile).map { t->
+                return evaluate(t.getAsFile())
+            }
             additionalClientTypeAnnotations = [
                     "@io.micronaut.context.annotation.BootstrapContextCompatible"
             ]

--- a/kubernetes-client-openapi/src/test/groovy/io/micronaut/kubernetes/client/openapi/DeleteObjectSpec.groovy
+++ b/kubernetes-client-openapi/src/test/groovy/io/micronaut/kubernetes/client/openapi/DeleteObjectSpec.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.kubernetes.client.openapi
+
+import io.micronaut.kubernetes.client.openapi.api.CoreV1Api
+import io.micronaut.kubernetes.client.openapi.model.V1ConfigMap
+import io.micronaut.kubernetes.client.openapi.model.V1Namespace
+import io.micronaut.kubernetes.client.openapi.model.V1ObjectMeta
+import io.micronaut.kubernetes.client.openapi.response.DeleteResponse
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.k3s.K3sContainer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+@MicronautTest
+class DeleteObjectSpec extends Specification implements TestPropertyProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeleteObjectSpec)
+
+    @Shared
+    @AutoCleanup
+    K3sContainer k3s = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.31.5-k3s1"))
+            .withLogConsumer(new Slf4jLogConsumer(logger))
+
+    @Shared
+    Path kubeConfigDir = Files.createTempDirectory("kube-temp-")
+
+    @Shared
+    Path kubeConfigFile = kubeConfigDir.resolve("config")
+
+    @Inject
+    CoreV1Api api
+
+    @Override
+    Map<String, String> getProperties() {
+        k3s.start()
+        kubeConfigFile.toFile().text = k3s.getKubeConfigYaml()
+        ["kubernetes.client.kube-config-path": "file:" + kubeConfigFile.toString()]
+    }
+
+    def cleanupSpec() {
+        if (kubeConfigFile != null) {
+            Files.deleteIfExists(kubeConfigFile)
+        }
+        if (kubeConfigDir) {
+            Files.deleteIfExists(kubeConfigDir)
+        }
+    }
+
+    def 'delete kubernetes objects'() {
+        given:
+        V1Namespace namespace = new V1Namespace()
+        namespace.kind('Namespace')
+        namespace.apiVersion('v1')
+        V1ObjectMeta namespaceMetadata = new V1ObjectMeta()
+        namespaceMetadata.name('micronaut-test-namespace')
+        namespace.metadata(namespaceMetadata)
+        api.createNamespace(namespace, null, null, null, null)
+
+        V1ConfigMap configMap = new V1ConfigMap()
+        configMap.kind('ConfigMap')
+        configMap.apiVersion('v1')
+        configMap.data(['test.properties': 'testKey=testValue'])
+        V1ObjectMeta configMapMetadata = new V1ObjectMeta()
+        configMapMetadata.name('micronaut-test-config-map')
+        configMap.metadata(configMapMetadata)
+        api.createNamespacedConfigMap('micronaut-test-namespace', configMap, null, null, null, null)
+
+        when:
+        DeleteResponse<V1ConfigMap> configMapResponse = api.deleteNamespacedConfigMap('micronaut-test-config-map', 'micronaut-test-namespace', null, null, null, null, null, null)
+        DeleteResponse<V1Namespace> namespaceResponse = api.deleteNamespace('micronaut-test-namespace', null, null, null, null, null, null)
+
+        then:
+        configMapResponse.object() == null
+        configMapResponse.status().apiVersion == 'v1'
+        configMapResponse.status().details.kind == 'configmaps'
+        configMapResponse.status().details.name == 'micronaut-test-config-map'
+
+        namespaceResponse.object().apiVersion == 'v1'
+        namespaceResponse.object().metadata.name == 'micronaut-test-namespace'
+        namespaceResponse.status() == null
+    }
+}

--- a/kubernetes-client-openapi/src/test/groovy/io/micronaut/kubernetes/client/openapi/DeleteObjectSpec.groovy
+++ b/kubernetes-client-openapi/src/test/groovy/io/micronaut/kubernetes/client/openapi/DeleteObjectSpec.groovy
@@ -75,8 +75,8 @@ class DeleteObjectSpec extends Specification implements TestPropertyProvider {
         api.createNamespacedConfigMap('micronaut-test-namespace', configMap, null, null, null, null)
 
         when:
-        DeleteResponse<V1ConfigMap> configMapResponse = api.deleteNamespacedConfigMap('micronaut-test-config-map', 'micronaut-test-namespace', null, null, null, null, null, null)
-        DeleteResponse<V1Namespace> namespaceResponse = api.deleteNamespace('micronaut-test-namespace', null, null, null, null, null, null)
+        DeleteResponse<V1ConfigMap> configMapResponse = api.deleteNamespacedConfigMap('micronaut-test-config-map', 'micronaut-test-namespace', null, null, null, null, null, null, null)
+        DeleteResponse<V1Namespace> namespaceResponse = api.deleteNamespace('micronaut-test-namespace', null, null, null, null, null, null, null)
 
         then:
         configMapResponse.object() == null

--- a/src/main/docs/guide/breaking.adoc
+++ b/src/main/docs/guide/breaking.adoc
@@ -1,3 +1,7 @@
+## Micronaut Kubernetes 8.x
+
+Micronaut Kubernetes 8.0.0 updates the official Kubernetes Client from v22 to v24.
+
 ## Micronaut Kubernetes 7.x
 
 Micronaut Kubernetes 7.0.0 updates the official Kubernetes Client from v19 to v22.

--- a/src/main/docs/guide/breaking.adoc
+++ b/src/main/docs/guide/breaking.adoc
@@ -2,6 +2,45 @@
 
 Micronaut Kubernetes 8.0.0 updates the official Kubernetes Client from v22 to v24.
 
+In Kubernetes Client OpenAPI client, delete methods have been modified to return `DeleteResponse` instead of `V1Status` or type of object that is being deleted.
+For example, `deleteNamespace` method of `CoreV1Api` class returned `V1Status`
+
+[source,java]
+----
+    @Delete("/api/v1/namespaces/{name}")
+    @Consumes({"application/json", "application/yaml", "application/vnd.kubernetes.protobuf", "application/cbor"})
+    V1Status deleteNamespace(
+        @PathVariable("name") @NotNull String name,
+        @QueryValue("pretty") @Nullable String pretty,
+        @QueryValue("dryRun") @Nullable String dryRun,
+        @QueryValue("gracePeriodSeconds") @Nullable Integer gracePeriodSeconds,
+        @QueryValue("ignoreStoreReadErrorWithClusterBreakingPotential") @Nullable Boolean ignoreStoreReadErrorWithClusterBreakingPotential,
+        @QueryValue("orphanDependents") @Nullable Boolean orphanDependents,
+        @QueryValue("propagationPolicy") @Nullable String propagationPolicy,
+        @Body @Nullable @Valid V1DeleteOptions body
+    );
+----
+
+but now returns `DeleteResponse<V1Namespace>`
+
+[source,java]
+----
+    @Delete("/api/v1/namespaces/{name}")
+    @Consumes({"application/json", "application/yaml", "application/vnd.kubernetes.protobuf", "application/cbor"})
+    DeleteResponse<V1Namespace> deleteNamespace(
+        @PathVariable("name") @NotNull String name,
+        @QueryValue("pretty") @Nullable String pretty,
+        @QueryValue("dryRun") @Nullable String dryRun,
+        @QueryValue("gracePeriodSeconds") @Nullable Integer gracePeriodSeconds,
+        @QueryValue("ignoreStoreReadErrorWithClusterBreakingPotential") @Nullable Boolean ignoreStoreReadErrorWithClusterBreakingPotential,
+        @QueryValue("orphanDependents") @Nullable Boolean orphanDependents,
+        @QueryValue("propagationPolicy") @Nullable String propagationPolicy,
+        @Body @Nullable @Valid V1DeleteOptions body
+    );
+----
+
+The same change has been applied to delete methods from Kubernetes Client OpenAPI Reactive client.
+
 ## Micronaut Kubernetes 7.x
 
 Micronaut Kubernetes 7.0.0 updates the official Kubernetes Client from v19 to v22.


### PR DESCRIPTION
In some cases when the client `delete` method is called, the kubernetes api service doesn't return what is set as returned type in the official kubernetes api spec.

For example, when this method is called
```
    @Delete("/api/v1/namespaces/{name}")
    @Consumes({"application/json", "application/yaml", "application/vnd.kubernetes.protobuf", "application/cbor"})
    V1Status deleteNamespace(...)
```
the kubernetes api service returns instance of object being deleted `V1Namespace` instead of `V1Status` which breaks our deserialization. What will be returned by the kuberenetes api service is determined by its configuration.

To fix the issue, I modified `delete` methods to return `DeleteResponse` instead of `V1Status` or type of object being deleted. `DeleteResponse` can contain either `V1Status` or instance of deleted object.

Example of new method:
```
    @Delete("/api/v1/namespaces/{name}")
    @Consumes({"application/json", "application/yaml", "application/vnd.kubernetes.protobuf", "application/cbor"})
    DeleteResponse<V1Namespace> deleteNamespace(...)
```