### PR TITLE
Modified example-kubernetes-informer to use existing cache of secrets

### DIFF
--- a/examples/example-kubernetes-informer/src/main/java/micronaut/informer/SecretInformerController.java
+++ b/examples/example-kubernetes-informer/src/main/java/micronaut/informer/SecretInformerController.java
@@ -15,28 +15,41 @@
  */
 package micronaut.informer;
 
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.informer.cache.Indexer;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.kubernetes.client.NamespaceResolver;
+import io.micronaut.kubernetes.client.informer.SharedIndexInformerFactory;
 
 import java.util.Collection;
 
 @Controller
 public class SecretInformerController {
 
-    private final SecretResourceEventHandler secretResourceEventHandler;
+    private final SharedIndexInformerFactory sharedIndexInformerFactory;
 
-    public SecretInformerController(SecretResourceEventHandler secretResourceEventHandler) {
-        this.secretResourceEventHandler = secretResourceEventHandler;
+    private final NamespaceResolver namespaceResolver;
+
+    public SecretInformerController(SharedIndexInformerFactory sharedIndexInformerFactory, NamespaceResolver namespaceResolver) {
+        this.sharedIndexInformerFactory = sharedIndexInformerFactory;
+        this.namespaceResolver = namespaceResolver;
     }
 
     @Get("/all")
     public Collection<V1Secret> all() {
-        return secretResourceEventHandler.getV1SecretMap().values();
+        String namespace = namespaceResolver.resolveNamespace();
+        SharedIndexInformer<V1Secret> informer = sharedIndexInformerFactory.getExistingSharedIndexInformer(namespace, V1Secret.class);
+        Indexer<V1Secret> indexer = informer.getIndexer();
+        return indexer.list();
     }
 
     @Get("/secret/{key}")
     public V1Secret secret(String key) {
-        return secretResourceEventHandler.getV1SecretMap().get(key);
+        String namespace = namespaceResolver.resolveNamespace();
+        SharedIndexInformer<V1Secret> informer = sharedIndexInformerFactory.getExistingSharedIndexInformer(namespace, V1Secret.class);
+        Indexer<V1Secret> indexer = informer.getIndexer();
+        return indexer.getByKey(namespace + "/" + key);
     }
 }

--- a/examples/example-kubernetes-informer/src/main/java/micronaut/informer/SecretResourceEventHandler.java
+++ b/examples/example-kubernetes-informer/src/main/java/micronaut/informer/SecretResourceEventHandler.java
@@ -18,34 +18,29 @@ package micronaut.informer;
 import io.kubernetes.client.informer.ResourceEventHandler;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
+import io.micronaut.context.annotation.Context;
 import io.micronaut.kubernetes.client.informer.Informer;
-import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
-
-@Singleton
+@Context
 @Informer(apiType = V1Secret.class, apiListType = V1SecretList.class)
 public class SecretResourceEventHandler implements ResourceEventHandler<V1Secret> {
 
-    private Map<String, V1Secret> v1SecretMap = new HashMap<>();
+    private static final Logger LOG = LoggerFactory.getLogger(SecretResourceEventHandler.class);
 
     @Override
     public void onAdd(V1Secret obj) {
-        v1SecretMap.put(obj.getMetadata().getName(), obj);
+        LOG.info("{} secret added!", obj.getMetadata().getName());
     }
 
     @Override
     public void onUpdate(V1Secret oldObj, V1Secret newObj) {
-        v1SecretMap.put(newObj.getMetadata().getName(), newObj);
+        LOG.info("{} secret updated!", oldObj.getMetadata().getName());
     }
 
     @Override
     public void onDelete(V1Secret obj, boolean deletedFinalStateUnknown) {
-        v1SecretMap.remove(obj.getMetadata().getName());
-    }
-
-    public Map<String, V1Secret> getV1SecretMap() {
-        return v1SecretMap;
+        LOG.info("{} secret deleted!", obj.getMetadata().getName());
     }
 }


### PR DESCRIPTION
The kubernetes informer already stores secrets so there is no need to store those in SecretResourceEventHandler too. Storing secrets in SecretResourceEventHandler and using those in tests can cause flaky tests since events are processed after the informer is marked as initialized so requests processed by SecretInformerController can find empty map in SecretResourceEventHandler.