### PR TITLE
Configure OpenAPI informer executable methods for startup processing

### DIFF
--- a/kubernetes-client-openapi-reactor/src/main/java/io/micronaut/kubernetes/client/openapi/reactor/annotation/KubernetesClientApiReactor.java
+++ b/kubernetes-client-openapi-reactor/src/main/java/io/micronaut/kubernetes/client/openapi/reactor/annotation/KubernetesClientApiReactor.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.kubernetes.client.openapi.reactor.annotation;
 
+import io.micronaut.context.annotation.Executable;
 import io.micronaut.core.annotation.Internal;
 
 import java.lang.annotation.ElementType;
@@ -27,6 +28,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Internal annotation used for finding kubernetes client api reactor beans.
  */
 @Internal
+@Executable(processOnStartup = true)
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
 public @interface KubernetesClientApiReactor {

--- a/kubernetes-client-openapi-watcher/src/main/java/io/micronaut/kubernetes/client/openapi/watcher/annotation/KubernetesClientApiWatcher.java
+++ b/kubernetes-client-openapi-watcher/src/main/java/io/micronaut/kubernetes/client/openapi/watcher/annotation/KubernetesClientApiWatcher.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.kubernetes.client.openapi.watcher.annotation;
 
+import io.micronaut.context.annotation.Executable;
 import io.micronaut.core.annotation.Internal;
 
 import java.lang.annotation.ElementType;
@@ -27,6 +28,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Internal annotation used for finding kubernetes client api watcher beans.
  */
 @Internal
+@Executable(processOnStartup = true)
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
 public @interface KubernetesClientApiWatcher {


### PR DESCRIPTION
Fix for the following warn message:
```
ExecutableMethodProcessor is supposed to be used with an annotation that has @Executable(processOnStartup = true). In the future version this will be an error.
```