### PR TITLE
Start 9.1.x at 9.1.0-SNAPSHOT with core 5.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=9.0.1-SNAPSHOT
+projectVersion=9.1.0-SNAPSHOT
 
 projectGroup=io.micronaut.kubernetes
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 micronaut-platform = "5.1.3"
-micronaut = "5.1.13"
+micronaut = "5.2.0"
 micronaut-gradle-plugin = "5.0.2"
 
 graal-svm = "25.0.4.1"


### PR DESCRIPTION
Starts the new minor branch `9.1.x` (created from `9.0.x`) at `9.1.0-SNAPSHOT` and moves it to Micronaut core 5.2.0.

Core 5.2 may only land in a new, unreleased minor of each library, so it does not go to `9.0.x`, whose minor is already released. Tracked in micronaut-projects/micronaut-core#13110.

Switching the default and Renovate base branch to `9.1.x` is left to the maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)